### PR TITLE
fix(security): harden remote template import (path traversal, ZIP bombs) with HTTP warning

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,6 +73,7 @@ android {
     }
 
     testOptions {
+        unitTests.isReturnDefaultValues = true
         unitTests.all {
             it.useJUnitPlatform()
         }
@@ -101,6 +102,8 @@ dependencies {
     testRuntimeOnly(libs.junit5.launcher)
     testImplementation(libs.junit5.params)
     testImplementation(libs.mockk)
+    // Real org.json implementation (the one in android.jar is a stub, so JSON can't be parsed in unit tests)
+    testImplementation("org.json:json:20240303")
 
     androidTestImplementation(libs.compose.test)
     debugImplementation(libs.androidx.compose.ui.test.manifest)

--- a/app/src/main/kotlin/app/floatdeck/data/RemoteTemplateLoader.kt
+++ b/app/src/main/kotlin/app/floatdeck/data/RemoteTemplateLoader.kt
@@ -2,99 +2,605 @@ package app.floatdeck.data
 
 import android.content.Context
 import android.util.Log
+import app.floatdeck.R
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
 import java.io.File
 import java.io.FileOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
 import java.net.URL
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 
 /**
- * 远程模板包加载器。
- * 从 URL 下载 ZIP 包，校验后解压到应用私有目录。
+ * Remote template pack loader.
+ * Downloads a ZIP from a URL, validates it, and extracts it into the app's private storage.
+ *
+ * Security-critical logic (path resolution, id validation, bounded copy,
+ * extraction/copy) lives in the [companion] and does not depend on [Context],
+ * so it can be unit-tested directly.
  */
 class RemoteTemplateLoader(
     private val context: Context,
 ) {
+    /** Thrown when the template already exists; the UI should ask whether to overwrite. */
+    class TemplateExistsException(
+        val templateId: String,
+        message: String,
+        messageResId: Int = 0,
+        args: Array<out Any> = emptyArray(),
+    ) : TemplateLoadException(message, messageResId, args)
+
+    /** Thrown when the user tries to download over HTTP (unencrypted); the UI should ask them to confirm. */
+    class HttpProtocolException(
+        message: String,
+    ) : TemplateLoadException(message)
+
+    /** Force-overwrite flag, set by the UI layer. */
+    var allowOverwrite = false
+
     companion object {
         private const val TAG = "RemoteTemplateLoader"
-        // 模板存储目录
-        private const val TEMPLATE_DIR = "remote_templates"
 
-        // ZIP 包最大 50MB
-        private const val MAX_ZIP_SIZE = 50L * 1024 * 1024
+        // Template storage directory
+        internal const val TEMPLATE_DIR = "remote_templates"
 
-        // 单个解压文件最大 10MB
-        private const val MAX_FILE_SIZE = 10L * 1024 * 1024
+        // Max ZIP size: 50MB
+        internal const val MAX_ZIP_SIZE = 50L * 1024 * 1024
 
-        // 允许的图片扩展名
-        private val IMAGE_EXTENSIONS = setOf("png", "jpg", "jpeg", "webp")
+        // Max size of a single extracted file: 10MB
+        internal const val MAX_FILE_SIZE = 10L * 1024 * 1024
 
-        // 允许的文件扩展名（图片 + json）
-        private val ALLOWED_EXTENSIONS = IMAGE_EXTENSIONS + "json"
+        // Max total extracted size: 200MB (ZIP-bomb defense)
+        internal const val MAX_TOTAL_EXTRACTED = 200L * 1024 * 1024
+
+        // Allowed image extensions
+        internal val IMAGE_EXTENSIONS = setOf("png", "jpg", "jpeg", "webp")
+
+        // Allowed file extensions (images + json)
+        internal val ALLOWED_EXTENSIONS = IMAGE_EXTENSIONS + "json"
+
+        private val TEMPLATE_ID_REGEX = Regex("[a-zA-Z0-9_-]+")
+
+        /**
+         * Safely resolves [childName] under [baseDir], returning null if the resulting path
+         * escapes [baseDir] (path traversal). The canonical-path comparison also defends
+         * against `..` and symlink-based bypasses.
+         */
+        internal fun safeResolveChild(baseDir: File, childName: String): File? {
+            if (childName.isBlank()) return null
+            // Reject absolute paths (Unix) and Windows drive letters.
+            if (childName.startsWith("/") || childName.startsWith("\\")) return null
+            if (childName.length >= 2 && childName[1] == ':') return null
+            val baseCanonical = baseDir.canonicalFile
+            val resolved = File(baseCanonical, childName).canonicalFile
+            val basePath = baseCanonical.path
+            if (resolved.path != basePath &&
+                !resolved.path.startsWith(basePath + File.separator)
+            ) {
+                return null
+            }
+            return resolved
+        }
+
+        /** Template id may only contain letters, digits, underscores and hyphens. */
+        internal fun isValidTemplateId(id: String): Boolean = id.matches(TEMPLATE_ID_REGEX)
+
+        /**
+         * Copies this stream to [out], throwing [IOException] once more than [maxBytes] have been
+         * written. Defends against decompression bombs that lie about their declared size
+         * ([ZipEntry] size is attacker-controlled; actual bytes are what count).
+         * Note: does NOT close the input stream — the caller owns its lifecycle (e.g. a
+         * [ZipInputStream] that must keep iterating).
+         */
+        internal fun InputStream.copyToWithLimit(out: OutputStream, maxBytes: Long): Long {
+            var written = 0L
+            val buffer = ByteArray(8192)
+            while (true) {
+                val read = read(buffer)
+                if (read < 0) break
+                written += read
+                if (written > maxBytes) {
+                    throw IOException("Exceeded maximum allowed size of $maxBytes bytes")
+                }
+                out.write(buffer, 0, read)
+            }
+            out.flush()
+            return written
+        }
+
+        /**
+         * Validates the ZIP and extracts it into [templateDir]. Does not depend on Context, for testability.
+         * @param overwrite whether to overwrite if the template already exists.
+         * @return the imported template id.
+         */
+        @JvmOverloads
+        internal fun extractTemplateFromZip(
+            zipFile: File,
+            templateDir: File,
+            overwrite: Boolean = false,
+        ): String {
+            try {
+                ZipInputStream(zipFile.inputStream().buffered()).use { zipInputStream ->
+                    var templateJson: JSONObject? = null
+                    var templateId: String? = null
+                    var zipFolderName: String? = null
+                    val entries = mutableListOf<ZipEntry>()
+
+                    // First pass: scan all entries.
+                    var entry: ZipEntry? = zipInputStream.nextEntry
+                    while (entry != null) {
+                        val name = entry.name
+                        Log.d(TAG, "Scanning ZIP entry: $name")
+
+                        // Reject absolute paths; the canonical-path check runs in the second pass.
+                        if (name.startsWith("/") || name.startsWith("\\")) {
+                            throw TemplateLoadException(
+                                "ZIP contains illegal path: $name",
+                                R.string.error_illegal_path,
+                                arrayOf(name),
+                            )
+                        }
+
+                        if (entry.isDirectory) {
+                            entry = zipInputStream.nextEntry
+                            continue
+                        }
+
+                        // ZIP structure requires: folder/file (exactly one level of directory).
+                        val slashCount = name.count { it == '/' }
+                        if (slashCount == 0) {
+                            throw TemplateLoadException(
+                                "ZIP structure error: files must be inside a subfolder",
+                                R.string.error_zip_structure,
+                            )
+                        }
+                        if (slashCount > 1) {
+                            Log.w(TAG, "Ignoring nested entry: $name")
+                            entry = zipInputStream.nextEntry
+                            continue
+                        }
+
+                        val folderName = name.substringBefore("/")
+                        val fileName = name.substringAfter("/")
+
+                        if (fileName.isEmpty()) {
+                            entry = zipInputStream.nextEntry
+                            continue
+                        }
+
+                        val extension =
+                            fileName.substringAfterLast(".", "").lowercase()
+                        if (extension !in ALLOWED_EXTENSIONS) {
+                            throw TemplateLoadException(
+                                "Unsupported file type: $fileName",
+                                R.string.error_unsupported_file_type,
+                                arrayOf(fileName),
+                            )
+                        }
+
+                        // Declared size is only a quick pre-check; the authoritative cap is the streamed
+                        // byte count in the second pass.
+                        if (entry.size > MAX_FILE_SIZE) {
+                            throw TemplateLoadException(
+                                "File too large: $fileName (max 10MB)",
+                                R.string.error_single_file_too_large,
+                                arrayOf(fileName),
+                            )
+                        }
+
+                        if (fileName == "template.json") {
+                            zipFolderName = folderName
+                            val content = zipInputStream.readBytes().toString(Charsets.UTF_8)
+                            templateJson =
+                                try {
+                                    JSONObject(content)
+                                } catch (e: Exception) {
+                                    throw TemplateLoadException(
+                                        "Invalid template.json: ${e.message}",
+                                        R.string.error_template_json_invalid_detail,
+                                        arrayOf(e.message ?: ""),
+                                    )
+                                }
+
+                            templateId = templateJson.optString("id")
+                            if (templateId.isNullOrBlank()) {
+                                throw TemplateLoadException(
+                                    "template.json is missing the id field",
+                                    R.string.error_template_no_id,
+                                )
+                            }
+                            if (!isValidTemplateId(templateId)) {
+                                throw TemplateLoadException(
+                                    "Template id may only contain letters, digits, underscores and hyphens",
+                                    R.string.error_invalid_template_id,
+                                )
+                            }
+                            if (!templateJson.has("wallpaper")) {
+                                throw TemplateLoadException(
+                                    "template.json is missing the wallpaper field",
+                                    R.string.error_template_no_wallpaper,
+                                )
+                            }
+                            if (!templateJson.has("portraits")) {
+                                throw TemplateLoadException(
+                                    "template.json is missing the portraits field",
+                                    R.string.error_template_no_portraits,
+                                )
+                            }
+                            Log.d(TAG, "Found template.json: id=$templateId, folder=$zipFolderName")
+                        }
+
+                        entries.add(entry)
+                        entry = zipInputStream.nextEntry
+                    }
+
+                    if (templateJson == null) {
+                        val allNames = entries.map { it.name }
+                        Log.e(TAG, "template.json not found. Entries: $allNames")
+                        throw TemplateLoadException(
+                            "template.json not found in ZIP",
+                            R.string.error_template_json_missing,
+                        )
+                    }
+
+                    // Verify that every image referenced by template.json is present in the ZIP.
+                    val fileNames =
+                        entries.map { it.name.substringAfterLast("/") }.toSet()
+                    Log.d(TAG, "Template files: $fileNames")
+
+                    val wallpaper = templateJson.getString("wallpaper")
+                    if (wallpaper !in fileNames) {
+                        throw TemplateLoadException(
+                            "Missing wallpaper file: $wallpaper",
+                            R.string.error_missing_wallpaper,
+                            arrayOf(wallpaper),
+                        )
+                    }
+
+                    val portraits = templateJson.getJSONObject("portraits")
+                    for (side in listOf("left", "right")) {
+                        val arr = portraits.optJSONArray(side) ?: continue
+                        for (i in 0 until arr.length()) {
+                            val file = arr.getJSONObject(i).getString("file")
+                            if (file !in fileNames) {
+                                throw TemplateLoadException(
+                                    "Missing portrait file: $file",
+                                    R.string.error_missing_portrait,
+                                    arrayOf(file),
+                                )
+                            }
+                        }
+                    }
+
+                    val safeId = templateId!!
+                    // Second pass: extract to the target dir (authoritative path-traversal + size checks).
+                    return writeZipEntries(
+                        zipFile,
+                        resolveTargetDir(templateDir, safeId, overwrite),
+                        entries.map { it.name },
+                    )
+                }
+            } catch (e: TemplateLoadException) {
+                Log.e(TAG, "Template validation failed: ${e.message}", e)
+                throw e
+            } catch (e: Exception) {
+                Log.e(TAG, "ZIP processing failed: ${e.message}", e)
+                throw TemplateLoadException(
+                    "ZIP processing failed: ${e.message}",
+                    R.string.error_zip_failed,
+                    arrayOf(e.message ?: ""),
+                )
+            }
+        }
+
+        /** Second-pass extraction: enforce canonical-path validation and streamed byte counting per entry. */
+        private fun writeZipEntries(zipFile: File, targetDir: File, entryNames: List<String>): String {
+            var totalExtracted = 0L
+            val allowed = entryNames.map { it.substringAfter("/") }.toSet()
+            ZipInputStream(zipFile.inputStream().buffered()).use { zis ->
+                var e: ZipEntry? = zis.nextEntry
+                while (e != null) {
+                    if (e.isDirectory) {
+                        e = zis.nextEntry
+                        continue
+                    }
+                    val slashCnt = e.name.count { it == '/' }
+                    if (slashCnt != 1) {
+                        e = zis.nextEntry
+                        continue
+                    }
+                    val fn = e.name.substringAfter("/")
+                    if (fn.isEmpty() || fn !in allowed) {
+                        e = zis.nextEntry
+                        continue
+                    }
+
+                    val outFile = safeResolveChild(targetDir, fn)
+                        ?: throw TemplateLoadException(
+                            "ZIP contains illegal path: ${e.name}",
+                            R.string.error_illegal_path,
+                            arrayOf(e.name),
+                        )
+
+                    Log.d(TAG, "Extracting: $fn")
+                    FileOutputStream(outFile).use { output ->
+                        val written = zis.copyToWithLimit(output, MAX_FILE_SIZE)
+                        totalExtracted += written
+                        if (totalExtracted > MAX_TOTAL_EXTRACTED) {
+                            throw TemplateLoadException(
+                                "Extracted content exceeds limit ($MAX_TOTAL_EXTRACTED bytes)",
+                                R.string.error_zip_total_too_large,
+                                arrayOf(MAX_TOTAL_EXTRACTED),
+                            )
+                        }
+                    }
+                    e = zis.nextEntry
+                }
+            }
+            return targetDir.name
+        }
+
+        /**
+         * Validates a local directory and copies the template into [templateDir].
+         * Does not depend on Context, for testability.
+         * @param overwrite whether to overwrite if the template already exists.
+         * @return the imported template id.
+         */
+        @JvmOverloads
+        internal fun copyTemplateFromDirectory(
+            sourceDir: File,
+            templateDir: File,
+            overwrite: Boolean = false,
+        ): String {
+            Log.d(TAG, "Validating directory: ${sourceDir.absolutePath}")
+            val templateJsonFile = File(sourceDir, "template.json")
+            if (!templateJsonFile.exists()) {
+                throw TemplateLoadException(
+                    "template.json not found in directory",
+                    R.string.error_template_json_missing,
+                )
+            }
+
+            val templateJson =
+                try {
+                    JSONObject(templateJsonFile.readText())
+                } catch (_: Exception) {
+                    throw TemplateLoadException(
+                        "Invalid template.json",
+                        R.string.error_template_json_invalid,
+                    )
+                }
+
+            val templateId = templateJson.optString("id")
+            if (templateId.isNullOrBlank()) {
+                throw TemplateLoadException(
+                    "template.json is missing the id field",
+                    R.string.error_template_no_id,
+                )
+            }
+            if (!isValidTemplateId(templateId)) {
+                throw TemplateLoadException(
+                    "Template id may only contain letters, digits, underscores and hyphens",
+                    R.string.error_invalid_template_id,
+                )
+            }
+            if (!templateJson.has("wallpaper")) {
+                throw TemplateLoadException(
+                    "template.json is missing the wallpaper field",
+                    R.string.error_template_no_wallpaper,
+                )
+            }
+            if (!templateJson.has("portraits")) {
+                throw TemplateLoadException(
+                    "template.json is missing the portraits field",
+                    R.string.error_template_no_portraits,
+                )
+            }
+
+            // Verify referenced files exist and defend against path traversal.
+            val wallpaper = templateJson.getString("wallpaper")
+            val wallpaperSrc = safeResolveChild(sourceDir, wallpaper)
+                ?: throw TemplateLoadException(
+                    "Illegal wallpaper path: $wallpaper",
+                    R.string.error_illegal_path,
+                    arrayOf(wallpaper),
+                )
+            if (!wallpaperSrc.exists()) {
+                throw TemplateLoadException(
+                    "Missing wallpaper file: $wallpaper",
+                    R.string.error_missing_wallpaper,
+                    arrayOf(wallpaper),
+                )
+            }
+            if (wallpaperSrc.length() > MAX_FILE_SIZE) {
+                throw TemplateLoadException(
+                    "File too large: $wallpaper (max 10MB)",
+                    R.string.error_single_file_too_large,
+                    arrayOf(wallpaper),
+                )
+            }
+
+            val portraits = templateJson.getJSONObject("portraits")
+            // Validate all portrait files before copying any.
+            val portraitFiles = mutableListOf<Pair<String, File>>()
+            for (side in listOf("left", "right")) {
+                val arr = portraits.optJSONArray(side) ?: continue
+                for (i in 0 until arr.length()) {
+                    val file = arr.getJSONObject(i).getString("file")
+                    val src = safeResolveChild(sourceDir, file)
+                        ?: throw TemplateLoadException(
+                            "Illegal portrait path: $file",
+                            R.string.error_illegal_path,
+                            arrayOf(file),
+                        )
+                    if (!src.exists()) {
+                        throw TemplateLoadException(
+                            "Missing portrait file: $file",
+                            R.string.error_missing_portrait,
+                            arrayOf(file),
+                        )
+                    }
+                    val ext = file.substringAfterLast(".", "").lowercase()
+                    if (ext !in ALLOWED_EXTENSIONS) {
+                        throw TemplateLoadException(
+                            "Unsupported file type: $file",
+                            R.string.error_unsupported_file_type,
+                            arrayOf(file),
+                        )
+                    }
+                    if (src.length() > MAX_FILE_SIZE) {
+                        throw TemplateLoadException(
+                            "File too large: $file (max 10MB)",
+                            R.string.error_single_file_too_large,
+                            arrayOf(file),
+                        )
+                    }
+                    portraitFiles.add(file to src)
+                }
+            }
+
+            val targetDir = resolveTargetDir(templateDir, templateId, overwrite)
+
+            // Copy template.json
+            templateJsonFile.copyTo(File(targetDir, "template.json"), overwrite = true)
+
+            // Copy the wallpaper (destination path also needs validation).
+            val wallpaperDest = safeResolveChild(targetDir, wallpaper)
+                ?: throw TemplateLoadException(
+                    "Illegal wallpaper destination path: $wallpaper",
+                    R.string.error_illegal_path,
+                    arrayOf(wallpaper),
+                )
+            wallpaperSrc.copyTo(wallpaperDest, overwrite = true)
+
+            // Copy the portraits.
+            for ((name, src) in portraitFiles) {
+                val dest = safeResolveChild(targetDir, name)
+                    ?: throw TemplateLoadException(
+                        "Illegal portrait destination path: $name",
+                        R.string.error_illegal_path,
+                        arrayOf(name),
+                    )
+                src.copyTo(dest, overwrite = true)
+            }
+
+            return templateId
+        }
+
+        /** Resolves the target directory; handles existing-template checks and overwrite. */
+        private fun resolveTargetDir(templateDir: File, templateId: String, overwrite: Boolean): File {
+            val targetDir = File(templateDir, templateId)
+            // Defense in depth: templateId already passed the regex check, but confirm the
+            // resolved path stays within templateDir.
+            val rootCanonical = templateDir.canonicalFile
+            val resolved = targetDir.canonicalFile
+            if (resolved.path != rootCanonical.path &&
+                !resolved.path.startsWith(rootCanonical.path + File.separator)
+            ) {
+                throw TemplateLoadException(
+                    "Template id resolves to an illegal path: $templateId",
+                    R.string.error_illegal_path,
+                    arrayOf(templateId),
+                )
+            }
+            if (targetDir.exists() && !overwrite) {
+                throw TemplateExistsException(
+                    templateId,
+                    "Template \"$templateId\" already exists, overwrite?",
+                    R.string.error_template_exists,
+                    arrayOf(templateId),
+                )
+            }
+            if (targetDir.exists()) targetDir.deleteRecursively()
+            targetDir.mkdirs()
+            return targetDir
+        }
     }
 
     /**
-     * 从 URL 下载并导入远程模板包。
-     * @param url ZIP 包的下载地址
-     * @return 导入成功的模板 ID
-     * @throws TemplateLoadException 各种错误情况
+     * Downloads a remote template pack from a URL and imports it.
+     * @param url download URL of the ZIP pack.
+     * @param allowHttp whether to allow HTTP (unencrypted). Defaults to false; the UI may pass
+     *   true after the user confirms the risk.
+     * @return the imported template id.
+     * @throws TemplateLoadException on various error conditions.
      */
-    suspend fun importFromUrl(url: String): String =
+    suspend fun importFromUrl(url: String, allowHttp: Boolean = false): String =
         withContext(Dispatchers.IO) {
-            val parsedUrl = validateUrl(url)
+            val parsedUrl = validateUrl(url, allowHttp)
             val tempFile = downloadZip(parsedUrl)
             try {
-                validateAndExtractZip(tempFile)
+                extractTemplateFromZip(tempFile, File(context.filesDir, TEMPLATE_DIR), allowOverwrite)
             } finally {
                 tempFile.delete()
             }
         }
 
     /**
-     * 从本地 ZIP 文件导入模板。
-     * @param zipFile 本地 ZIP 文件
-     * @return 导入成功的模板 ID
-     * @throws TemplateLoadException 各种错误情况
+     * Imports a template from a local ZIP file.
+     * @param zipFile the local ZIP file.
+     * @return the imported template id.
+     * @throws TemplateLoadException on various error conditions.
      */
     suspend fun importFromZip(zipFile: File): String =
         withContext(Dispatchers.IO) {
             if (!zipFile.exists()) {
-                throw TemplateLoadException("文件不存在")
+                throw TemplateLoadException("File not found", R.string.error_file_not_found)
             }
             if (zipFile.length() > MAX_ZIP_SIZE) {
-                throw TemplateLoadException("文件过大（最大 50MB）")
+                throw TemplateLoadException("File too large (max 50MB)", R.string.error_file_too_large)
             }
-            validateAndExtractZip(zipFile)
+            extractTemplateFromZip(zipFile, File(context.filesDir, TEMPLATE_DIR), allowOverwrite)
         }
 
     /**
-     * 从本地目录导入模板。
-     * 目录必须包含 template.json 和引用的所有图片文件。
-     * @param dir 本地模板目录
-     * @return 导入成功的模板 ID
-     * @throws TemplateLoadException 各种错误情况
+     * Imports a template from a local directory.
+     * The directory must contain template.json and every referenced image.
+     * @param dir the local template directory.
+     * @return the imported template id.
+     * @throws TemplateLoadException on various error conditions.
      */
     suspend fun importFromDirectory(dir: File): String =
         withContext(Dispatchers.IO) {
             if (!dir.exists() || !dir.isDirectory) {
-                throw TemplateLoadException("目录不存在")
+                throw TemplateLoadException("Directory not found", R.string.error_dir_not_found)
             }
-            validateAndCopyDirectory(dir)
+            copyTemplateFromDirectory(dir, File(context.filesDir, TEMPLATE_DIR), allowOverwrite)
         }
 
-    private fun validateUrl(url: String): URL {
-        if (url.isBlank()) throw TemplateLoadException("URL 不能为空")
+    private fun validateUrl(url: String, allowHttp: Boolean): URL {
+        if (url.isBlank()) {
+            throw TemplateLoadException("URL cannot be empty", R.string.error_url_empty)
+        }
         val parsed =
             try {
                 URL(url)
             } catch (_: Exception) {
-                throw TemplateLoadException("URL 格式无效")
+                throw TemplateLoadException("Invalid URL format", R.string.error_url_invalid)
             }
-        if (parsed.protocol !in listOf("http", "https")) {
-            throw TemplateLoadException("仅支持 HTTP/HTTPS 协议")
+        val host = parsed.host
+        if (host.isNullOrBlank()) {
+            throw TemplateLoadException("URL is missing a hostname", R.string.error_url_no_host)
+        }
+        when (parsed.protocol) {
+            "https" -> { /* encrypted, allow */}
+            "http" -> {
+                // Unencrypted: block by default; the settings UI asks the user to confirm
+                // the risk and retries with allowHttp = true.
+                if (!allowHttp) {
+                    throw HttpProtocolException(
+                        "URL uses HTTP (unencrypted); the UI should ask the user to confirm",
+                    )
+                }
+            }
+            else -> throw TemplateLoadException(
+                "Only HTTP/HTTPS protocols are supported",
+                R.string.error_unsupported_protocol,
+            )
         }
         return parsed
     }
@@ -109,7 +615,7 @@ class RemoteTemplateLoader(
 
             val contentLength = connection.contentLengthLong
             if (contentLength > MAX_ZIP_SIZE) {
-                throw TemplateLoadException("文件过大（最大 50MB）")
+                throw TemplateLoadException("File too large (max 50MB)", R.string.error_file_too_large)
             }
 
             var totalRead = 0L
@@ -120,7 +626,7 @@ class RemoteTemplateLoader(
                     while (input.read(buffer).also { read = it } != -1) {
                         totalRead += read
                         if (totalRead > MAX_ZIP_SIZE) {
-                            throw TemplateLoadException("文件过大（最大 50MB）")
+                            throw TemplateLoadException("File too large (max 50MB)", R.string.error_file_too_large)
                         }
                         output.write(buffer, 0, read)
                     }
@@ -128,7 +634,7 @@ class RemoteTemplateLoader(
             }
 
             if (totalRead == 0L) {
-                throw TemplateLoadException("下载的文件为空")
+                throw TemplateLoadException("Downloaded file is empty", R.string.error_download_empty)
             }
 
             return tempFile
@@ -137,279 +643,14 @@ class RemoteTemplateLoader(
             throw e
         } catch (_: Exception) {
             tempFile.delete()
-            throw TemplateLoadException("下载失败，请检查网络连接")
-        }
-    }
-
-    /** 模板已存在时抛出此异常，UI 层应询问用户是否覆盖 */
-    class TemplateExistsException(
-        val templateId: String,
-        message: String,
-    ) : TemplateLoadException(message)
-
-    /** 强制覆盖标志，由 UI 层设置 */
-    var allowOverwrite = false
-
-    private fun validateAndExtractZip(zipFile: File): String {
-        val templateDir = File(context.filesDir, TEMPLATE_DIR)
-
-        try {
-            ZipInputStream(zipFile.inputStream().buffered()).use { zipInputStream ->
-                var templateJson: JSONObject? = null
-                var templateId: String? = null
-                var zipFolderName: String? = null
-                val entries = mutableListOf<ZipEntry>()
-
-                // 第一遍：扫描所有条目
-                var entry: ZipEntry? = zipInputStream.nextEntry
-                while (entry != null) {
-                    val name = entry.name
-                    Log.d(TAG, "Scanning ZIP entry: $name")
-
-                    if (name.contains("..")) {
-                        throw TemplateLoadException("ZIP 包含非法路径: $name")
-                    }
-
-                    if (entry.isDirectory) {
-                        entry = zipInputStream.nextEntry
-                        continue
-                    }
-
-                    // ZIP 结构要求：文件夹名/文件名（严格一层目录）
-                    val slashCount = name.count { it == '/' }
-                    if (slashCount == 0) {
-                        throw TemplateLoadException(
-                            "ZIP 结构错误：文件必须在子文件夹中（如 my_template/template.json）",
-                        )
-                    }
-                    if (slashCount > 1) {
-                        Log.w(TAG, "Ignoring nested entry: $name")
-                        entry = zipInputStream.nextEntry
-                        continue
-                    }
-
-                    val folderName = name.substringBefore("/")
-                    val fileName = name.substringAfter("/")
-
-                    if (fileName.isEmpty()) {
-                        entry = zipInputStream.nextEntry
-                        continue
-                    }
-
-                    val extension =
-                        fileName.substringAfterLast(".", "").lowercase()
-                    if (extension !in ALLOWED_EXTENSIONS) {
-                        throw TemplateLoadException(
-                            "包含不支持的文件类型：$fileName（仅支持 png/jpg/webp/json）",
-                        )
-                    }
-
-                    if (entry.size > MAX_FILE_SIZE) {
-                        throw TemplateLoadException("单个文件过大：$fileName（最大 10MB）")
-                    }
-
-                    if (fileName == "template.json") {
-                        zipFolderName = folderName
-                        val content =
-                            zipInputStream.bufferedReader().readText()
-                        templateJson =
-                            try {
-                                JSONObject(content)
-                            } catch (e: Exception) {
-                                throw TemplateLoadException("template.json 格式无效: ${e.message}")
-                            }
-
-                        templateId = templateJson.optString("id")
-                        if (templateId.isNullOrBlank()) {
-                            throw TemplateLoadException("template.json 缺少 id 字段")
-                        }
-                        if (!templateJson.has("wallpaper")) {
-                            throw TemplateLoadException("template.json 缺少 wallpaper 字段")
-                        }
-                        if (!templateJson.has("portraits")) {
-                            throw TemplateLoadException("template.json 缺少 portraits 字段")
-                        }
-                        if (!templateId!!.matches(Regex("[a-zA-Z0-9_-]+"))) {
-                            throw TemplateLoadException(
-                                "模板 ID 只能包含字母、数字、下划线和连字符",
-                            )
-                        }
-                        Log.d(TAG, "Found template.json: id=$templateId, folder=$zipFolderName")
-                    }
-
-                    entries.add(entry)
-                    entry = zipInputStream.nextEntry
-                }
-
-                if (templateJson == null) {
-                    val allNames = entries.map { it.name }
-                    Log.e(TAG, "template.json not found. Entries: $allNames")
-                    throw TemplateLoadException("ZIP 中未找到 template.json")
-                }
-
-                // 校验 template.json 引用的图片是否都在 ZIP 中
-                val fileNames =
-                    entries.map { it.name.substringAfterLast("/") }.toSet()
-                Log.d(TAG, "Template files: $fileNames")
-
-                val wallpaper = templateJson.getString("wallpaper")
-                if (wallpaper !in fileNames) {
-                    throw TemplateLoadException("缺少壁纸文件：$wallpaper")
-                }
-
-                val portraits = templateJson.getJSONObject("portraits")
-                for (side in listOf("left", "right")) {
-                    val arr = portraits.optJSONArray(side) ?: continue
-                    for (i in 0 until arr.length()) {
-                        val file = arr.getJSONObject(i).getString("file")
-                        if (file !in fileNames) {
-                            throw TemplateLoadException("缺少立绘文件：$file")
-                        }
-                    }
-                }
-
-                // 检查是否已存在
-                val targetDir = File(templateDir, templateId!!)
-                if (targetDir.exists() && !allowOverwrite) {
-                    throw TemplateExistsException(
-                        templateId!!,
-                        "模板 \"$templateId\" 已存在，是否覆盖？",
-                    )
-                }
-
-                // 第二遍：解压到目标目录
-                if (targetDir.exists()) targetDir.deleteRecursively()
-                targetDir.mkdirs()
-
-                ZipInputStream(zipFile.inputStream().buffered()).use { zis ->
-                    var e: ZipEntry? = zis.nextEntry
-                    while (e != null) {
-                        if (e.isDirectory) {
-                            e = zis.nextEntry
-                            continue
-                        }
-                        val slashCnt = e.name.count { it == '/' }
-                        if (slashCnt != 1) {
-                            e = zis.nextEntry
-                            continue
-                        }
-                        val fn = e.name.substringAfter("/")
-                        if (fn.isEmpty()) {
-                            e = zis.nextEntry
-                            continue
-                        }
-
-                        val outFile = File(targetDir, fn)
-                        if (!outFile.canonicalPath.startsWith(targetDir.canonicalPath)) {
-                            throw TemplateLoadException("ZIP 包含非法路径")
-                        }
-
-                        Log.d(TAG, "Extracting: $fn")
-                        FileOutputStream(outFile).use { output ->
-                            zis.copyTo(output)
-                        }
-                        e = zis.nextEntry
-                    }
-                }
-
-                return templateId!!
-            }
-        } catch (e: TemplateLoadException) {
-            Log.e(TAG, "Template validation failed: ${e.message}", e)
-            throw e
-        } catch (e: Exception) {
-            Log.e(TAG, "ZIP processing failed: ${e.message}", e)
-            throw TemplateLoadException("ZIP 处理失败: ${e.message}")
-        }
-    }
-
-    /**
-     * 从本地目录校验并复制模板到应用私有目录。
-     */
-    private fun validateAndCopyDirectory(sourceDir: File): String {
-        Log.d(TAG, "Validating directory: ${sourceDir.absolutePath}")
-        val templateJsonFile = File(sourceDir, "template.json")
-        if (!templateJsonFile.exists()) {
-            throw TemplateLoadException("目录中未找到 template.json")
-        }
-
-        val templateJson =
-            try {
-                JSONObject(templateJsonFile.readText())
-            } catch (_: Exception) {
-                throw TemplateLoadException("template.json 格式无效")
-            }
-
-        val templateId = templateJson.optString("id")
-        if (templateId.isNullOrBlank()) {
-            throw TemplateLoadException("template.json 缺少 id 字段")
-        }
-        if (!templateJson.has("wallpaper")) {
-            throw TemplateLoadException("template.json 缺少 wallpaper 字段")
-        }
-        if (!templateJson.has("portraits")) {
-            throw TemplateLoadException("template.json 缺少 portraits 字段")
-        }
-        if (!templateId.matches(Regex("[a-zA-Z0-9_-]+"))) {
-            throw TemplateLoadException("模板 ID 只能包含字母、数字、下划线和连字符")
-        }
-
-        // 校验引用的文件是否存在
-        val wallpaper = templateJson.getString("wallpaper")
-        if (!File(sourceDir, wallpaper).exists()) {
-            throw TemplateLoadException("缺少壁纸文件：$wallpaper")
-        }
-
-        val portraits = templateJson.getJSONObject("portraits")
-        for (side in listOf("left", "right")) {
-            val arr = portraits.optJSONArray(side) ?: continue
-            for (i in 0 until arr.length()) {
-                val file = arr.getJSONObject(i).getString("file")
-                if (!File(sourceDir, file).exists()) {
-                    throw TemplateLoadException("缺少立绘文件：$file")
-                }
-                val ext = file.substringAfterLast(".", "").lowercase()
-                if (ext !in ALLOWED_EXTENSIONS) {
-                    throw TemplateLoadException("不支持的文件类型：$file")
-                }
-                val f = File(sourceDir, file)
-                if (f.length() > MAX_FILE_SIZE) {
-                    throw TemplateLoadException("单个文件过大：$file（最大 10MB）")
-                }
-            }
-        }
-
-        // 复制到目标目录
-        val templateDir = File(context.filesDir, TEMPLATE_DIR)
-        val targetDir = File(templateDir, templateId)
-        if (targetDir.exists() && !allowOverwrite) {
-            throw TemplateExistsException(
-                templateId,
-                "模板 \"$templateId\" 已存在，是否覆盖？",
+            throw TemplateLoadException(
+                "Download failed, please check network connection",
+                R.string.error_download_failed,
             )
         }
-        if (targetDir.exists()) targetDir.deleteRecursively()
-        targetDir.mkdirs()
-
-        // 复制 template.json
-        templateJsonFile.copyTo(File(targetDir, "template.json"))
-
-        // 复制壁纸
-        File(sourceDir, wallpaper).copyTo(File(targetDir, wallpaper))
-
-        // 复制立绘
-        for (side in listOf("left", "right")) {
-            val arr = portraits.optJSONArray(side) ?: continue
-            for (i in 0 until arr.length()) {
-                val file = arr.getJSONObject(i).getString("file")
-                File(sourceDir, file).copyTo(File(targetDir, file))
-            }
-        }
-
-        return templateId
     }
 
-    /** 获取已导入的远程模板列表。 */
+    /** Returns the list of imported remote templates. */
     fun getImportedTemplates(): List<TemplateDef> {
         val templateDir =
             File(context.filesDir, TEMPLATE_DIR)
@@ -424,17 +665,35 @@ class RemoteTemplateLoader(
             ?: emptyList()
     }
 
-    /** 删除已导入的模板。 */
+    /** Deletes an imported template. */
     fun deleteTemplate(templateId: String): Boolean {
-        val dir =
-            File(
-                context.filesDir,
-                "$TEMPLATE_DIR/$templateId",
-            )
+        if (!isValidTemplateId(templateId)) {
+            Log.w(TAG, "Refusing to delete invalid template id: $templateId")
+            return false
+        }
+        val templateRoot = File(context.filesDir, TEMPLATE_DIR).canonicalFile
+        val dir = File(context.filesDir, "$TEMPLATE_DIR/$templateId")
+        val resolved = dir.canonicalFile
+        if (resolved.path != templateRoot.path &&
+            !resolved.path.startsWith(templateRoot.path + File.separator)
+        ) {
+            Log.w(TAG, "Refusing to delete path outside template dir: ${dir.path}")
+            return false
+        }
         return dir.deleteRecursively()
     }
 }
 
+/**
+ * Base type for all template import/load errors.
+ *
+ * To support i18n without coupling the loader to Android [android.content.Context],
+ * user-facing errors carry a [messageResId] (a `R.string.*`) plus formatting [args].
+ * The UI layer resolves them via `context.getString(messageResId, *args)` when set;
+ * otherwise it falls back to the English [message] literal (used for logging).
+ */
 open class TemplateLoadException(
     message: String,
+    val messageResId: Int = 0,
+    val args: Array<out Any> = emptyArray(),
 ) : Exception(message)

--- a/app/src/main/kotlin/app/floatdeck/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/app/floatdeck/settings/SettingsActivity.kt
@@ -58,6 +58,7 @@ import app.floatdeck.data.PortraitEffect
 import app.floatdeck.data.RemoteTemplateLoader
 import app.floatdeck.data.SettingsRepository
 import app.floatdeck.data.TemplateDef
+import app.floatdeck.data.RemoteTemplateLoader.HttpProtocolException
 import app.floatdeck.data.TemplateLoadException
 import app.floatdeck.data.UpdateChecker
 import app.floatdeck.service.FloatDeckWallpaperService
@@ -116,6 +117,7 @@ fun SettingsScreen(
     var urlText by remember { mutableStateOf("") }
     var isLoading by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf("") }
+    var showHttpWarning by remember { mutableStateOf(false) }
     var updateChecking by remember { mutableStateOf(false) }
     var updateAvailable by remember { mutableStateOf<app.floatdeck.data.ReleaseInfo?>(null) }
     var updateError by remember { mutableStateOf<String?>(null) }
@@ -143,7 +145,16 @@ fun SettingsScreen(
 
     remember { refreshRemoteTemplates() }
 
-    fun importTemplate() {
+    // Resolve an import error to a localized message: prefer the loader's messageResId
+    // (carried on TemplateLoadException for i18n) over the English literal.
+    fun localizedError(e: Throwable): String =
+        if (e is TemplateLoadException && e.messageResId != 0) {
+            context.getString(e.messageResId, *e.args)
+        } else {
+            e.message ?: context.getString(R.string.error_import_failed)
+        }
+
+    fun importTemplate(allowHttp: Boolean = false) {
         if (urlText.isBlank()) {
             errorMessage = context.getString(R.string.error_enter_url)
             return
@@ -152,14 +163,17 @@ fun SettingsScreen(
         errorMessage = ""
         scope.launch {
             try {
-                val id = remoteLoader.importFromUrl(urlText)
+                val id = remoteLoader.importFromUrl(urlText, allowHttp)
                 refreshRemoteTemplates()
                 urlText = ""
                 templateId = id
                 repo.setTemplate(id)
                 Toast.makeText(context, context.getString(R.string.import_success, id), Toast.LENGTH_SHORT).show()
+            } catch (e: HttpProtocolException) {
+                // HTTP (unencrypted): show a confirmation dialog; retry with allowHttp on accept.
+                showHttpWarning = true
             } catch (e: Exception) {
-                errorMessage = e.message ?: context.getString(R.string.error_import_failed)
+                errorMessage = localizedError(e)
             } finally {
                 isLoading = false
             }
@@ -183,7 +197,7 @@ fun SettingsScreen(
                 Toast.makeText(context, context.getString(R.string.import_success, id), Toast.LENGTH_SHORT).show()
             } catch (e: Exception) {
                 android.util.Log.e("FloatDeck", "Local ZIP import failed", e)
-                errorMessage = e.message ?: context.getString(R.string.error_import_failed)
+                errorMessage = localizedError(e)
             } finally {
                 isLoading = false
             }
@@ -224,7 +238,7 @@ fun SettingsScreen(
                 Toast.makeText(context, context.getString(R.string.import_success, id), Toast.LENGTH_SHORT).show()
             } catch (e: Exception) {
                 android.util.Log.e("FloatDeck", "Local directory import failed", e)
-                errorMessage = e.message ?: context.getString(R.string.error_import_failed)
+                errorMessage = localizedError(e)
             } finally {
                 isLoading = false
             }
@@ -607,6 +621,27 @@ fun SettingsScreen(
                         confirmButton = {
                             TextButton(onClick = { updateError = null }) {
                                 Text(stringResource(android.R.string.ok))
+                            }
+                        },
+                    )
+                }
+
+                if (showHttpWarning) {
+                    AlertDialog(
+                        onDismissRequest = { showHttpWarning = false },
+                        title = { Text(stringResource(R.string.http_warning_title)) },
+                        text = {
+                            Text(stringResource(R.string.http_warning_message))
+                        },
+                        confirmButton = {
+                            TextButton(onClick = {
+                                showHttpWarning = false
+                                importTemplate(allowHttp = true)
+                            }) { Text(stringResource(R.string.http_warning_continue)) }
+                        },
+                        dismissButton = {
+                            TextButton(onClick = { showHttpWarning = false }) {
+                                Text(stringResource(android.R.string.cancel))
                             }
                         },
                     )

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -61,4 +61,23 @@
     <string name="update_timeout">请求超时，请稍后重试</string>
     <string name="open_source_licenses">开源许可</string>
     <string name="back">返回</string>
+
+    <!-- 远程模板导入：安全提示 -->
+    <string name="http_warning_title">不安全的连接</string>
+    <string name="http_warning_message">该地址使用 HTTP（非加密），下载内容可能被第三方窥探或篡改。\n是否继续？</string>
+    <string name="http_warning_continue">继续</string>
+    <string name="error_illegal_path">路径非法：%1$s</string>
+    <string name="error_zip_total_too_large">解压内容总量超出上限（%1$s 字节）</string>
+
+    <!-- 远程模板导入：校验错误 -->
+    <string name="error_url_no_host">URL 缺少主机名</string>
+    <string name="error_single_file_too_large">单个文件过大：%1$s（最大 10MB）</string>
+    <string name="error_template_json_invalid">template.json 格式无效</string>
+    <string name="error_template_json_invalid_detail">template.json 格式无效：%1$s</string>
+    <string name="error_template_no_id">template.json 缺少 id 字段</string>
+    <string name="error_invalid_template_id">模板 ID 只能包含字母、数字、下划线和连字符</string>
+    <string name="error_template_no_wallpaper">template.json 缺少 wallpaper 字段</string>
+    <string name="error_template_no_portraits">template.json 缺少 portraits 字段</string>
+    <string name="error_template_json_missing">未找到 template.json</string>
+    <string name="error_zip_failed">ZIP 处理失败：%1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,4 +61,23 @@
     <string name="update_timeout">Request timeout, please try again later</string>
     <string name="open_source_licenses">Open Source Licenses</string>
     <string name="back">Back</string>
+
+    <!-- Remote template import: security prompts -->
+    <string name="http_warning_title">Insecure connection</string>
+    <string name="http_warning_message">This URL uses HTTP (unencrypted). The download could be observed or tampered with by third parties. Continue?</string>
+    <string name="http_warning_continue">Continue</string>
+    <string name="error_illegal_path">Illegal path: %1$s</string>
+    <string name="error_zip_total_too_large">Extracted content exceeds size limit (%1$s bytes)</string>
+
+    <!-- Remote template import: validation errors -->
+    <string name="error_url_no_host">URL is missing a hostname</string>
+    <string name="error_single_file_too_large">File too large: %1$s (max 10MB)</string>
+    <string name="error_template_json_invalid">Invalid template.json</string>
+    <string name="error_template_json_invalid_detail">Invalid template.json: %1$s</string>
+    <string name="error_template_no_id">template.json is missing the id field</string>
+    <string name="error_invalid_template_id">Template id may only contain letters, digits, underscores and hyphens</string>
+    <string name="error_template_no_wallpaper">template.json is missing the wallpaper field</string>
+    <string name="error_template_no_portraits">template.json is missing the portraits field</string>
+    <string name="error_template_json_missing">template.json not found</string>
+    <string name="error_zip_failed">ZIP processing failed: %1$s</string>
 </resources>

--- a/app/src/test/kotlin/app/floatdeck/data/RemoteTemplateLoaderIntegrationTest.kt
+++ b/app/src/test/kotlin/app/floatdeck/data/RemoteTemplateLoaderIntegrationTest.kt
@@ -1,0 +1,219 @@
+package app.floatdeck.data
+
+import app.floatdeck.R
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/**
+ * End-to-end tests for [RemoteTemplateLoader.extractTemplateFromZip] and
+ * [RemoteTemplateLoader.copyTemplateFromDirectory] (companion functions, no Android Context needed).
+ * Covers happy-path import, overwrite, duplicate detection, path-traversal rejection and
+ * ZIP-bomb rejection.
+ */
+class RemoteTemplateLoaderIntegrationTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    private val minimalPng: ByteArray =
+        byteArrayOf(
+            0x89.toByte(),
+            0x50,
+            0x4E,
+            0x47,
+            0x0D,
+            0x0A,
+            0x1A,
+            0x0A,
+        )
+
+    private fun templateJson(
+        id: String = "test_template",
+        wallpaper: String = "bg.png",
+        left: List<String> = listOf("a.png"),
+        right: List<String> = listOf("b.png"),
+    ): String {
+        val leftArr = left.joinToString(",") { """{"file":"$it","label":"$it"}""" }
+        val rightArr = right.joinToString(",") { """{"file":"$it","label":"$it"}""" }
+        return """{"id":"$id","name":"T","wallpaper":"$wallpaper",""" +
+            """"portraits":{"left":[$leftArr],"right":[$rightArr]}}"""
+    }
+
+    private fun writeZip(zipFile: File, folder: String, files: Map<String, ByteArray>) {
+        ZipOutputStream(zipFile.outputStream()).use { zos ->
+            files.forEach { (name, data) ->
+                zos.putNextEntry(ZipEntry("$folder/$name"))
+                zos.write(data)
+                zos.closeEntry()
+            }
+        }
+    }
+
+    private fun templateRoot(): File = File(tempDir, "store").apply { mkdirs() }
+
+    @Test
+    fun `zip - valid template extracts successfully`() {
+        val zip = File(tempDir, "ok.zip")
+        writeZip(
+            zip,
+            "test_template",
+            mapOf(
+                "template.json" to templateJson().toByteArray(),
+                "bg.png" to minimalPng,
+                "a.png" to minimalPng,
+                "b.png" to minimalPng,
+            ),
+        )
+
+        val id = RemoteTemplateLoader.extractTemplateFromZip(zip, templateRoot())
+        assertEquals("test_template", id)
+        val out = File(templateRoot(), "test_template")
+        assertTrue(File(out, "template.json").exists())
+        assertTrue(File(out, "bg.png").exists())
+        assertTrue(File(out, "a.png").exists())
+        assertTrue(File(out, "b.png").exists())
+    }
+
+    @Test
+    fun `zip - duplicate without overwrite throws TemplateExistsException`() {
+        val zip = File(tempDir, "ok.zip")
+        writeZip(
+            zip,
+            "test_template",
+            mapOf(
+                "template.json" to templateJson().toByteArray(),
+                "bg.png" to minimalPng,
+                "a.png" to minimalPng,
+                "b.png" to minimalPng,
+            ),
+        )
+        val root = templateRoot()
+        RemoteTemplateLoader.extractTemplateFromZip(zip, root)
+
+        val second = assertThrows<RemoteTemplateLoader.TemplateExistsException> {
+            RemoteTemplateLoader.extractTemplateFromZip(zip, root, overwrite = false)
+        }
+        assertEquals("test_template", second.templateId)
+    }
+
+    @Test
+    fun `zip - overwrite replaces existing template`() {
+        val zip = File(tempDir, "ok.zip")
+        writeZip(
+            zip,
+            "test_template",
+            mapOf(
+                "template.json" to templateJson().toByteArray(),
+                "bg.png" to minimalPng,
+                "a.png" to minimalPng,
+                "b.png" to minimalPng,
+            ),
+        )
+        val root = templateRoot()
+        RemoteTemplateLoader.extractTemplateFromZip(zip, root)
+
+        // Overwrite must not throw.
+        val id = RemoteTemplateLoader.extractTemplateFromZip(zip, root, overwrite = true)
+        assertEquals("test_template", id)
+    }
+
+    @Test
+    fun `zip - invalid id is rejected`() {
+        val zip = File(tempDir, "bad.zip")
+        writeZip(
+            zip,
+            "x",
+            mapOf(
+                "template.json" to templateJson(id = "../evil").toByteArray(),
+                "../evil" to minimalPng, // placeholder filename; the goal is to validate the id check
+            ).filterKeys { it != "../evil" },
+        )
+        // An invalid id must fail at the validation stage.
+        assertThrows<TemplateLoadException> {
+            RemoteTemplateLoader.extractTemplateFromZip(zip, templateRoot())
+        }
+    }
+
+    @Test
+    fun `zip - missing template_json fails`() {
+        val zip = File(tempDir, "nojson.zip")
+        writeZip(zip, "x", mapOf("bg.png" to minimalPng))
+        assertThrows<TemplateLoadException> {
+            RemoteTemplateLoader.extractTemplateFromZip(zip, templateRoot())
+        }
+    }
+
+    @Test
+    fun `directory - valid directory copies successfully`() {
+        val src = File(tempDir, "src")
+        src.mkdirs()
+        File(src, "template.json").writeText(templateJson())
+        File(src, "bg.png").writeBytes(minimalPng)
+        File(src, "a.png").writeBytes(minimalPng)
+        File(src, "b.png").writeBytes(minimalPng)
+
+        val id = RemoteTemplateLoader.copyTemplateFromDirectory(src, templateRoot())
+        assertEquals("test_template", id)
+        val out = File(templateRoot(), "test_template")
+        assertTrue(File(out, "bg.png").exists())
+        assertTrue(File(out, "a.png").exists())
+        assertTrue(File(out, "b.png").exists())
+    }
+
+    @Test
+    fun `directory - path traversal in wallpaper is rejected`() {
+        val src = File(tempDir, "evil")
+        src.mkdirs()
+        // Build a template.json that references an out-of-dir path, and place a real file there.
+        File(tempDir, "secret.png").writeBytes(minimalPng)
+        File(src, "template.json").writeText(templateJson(wallpaper = "../secret.png"))
+        File(src, "a.png").writeBytes(minimalPng)
+        File(src, "b.png").writeBytes(minimalPng)
+
+        val ex = assertThrows<TemplateLoadException> {
+            RemoteTemplateLoader.copyTemplateFromDirectory(src, templateRoot())
+        }
+        // Must be rejected and must not write secret.png into the target dir.
+        assertFalse(File(templateRoot(), "secret.png").exists())
+        // The error carries the localized resource id (the actual display string is
+        // resolved by the UI, so the test asserts the resource id, not the text).
+        assertEquals(R.string.error_illegal_path, ex.messageResId)
+    }
+
+    @Test
+    fun `directory - path traversal in portrait file is rejected`() {
+        val src = File(tempDir, "evil2")
+        src.mkdirs()
+        File(tempDir, "steal.png").writeBytes(minimalPng)
+        File(src, "template.json").writeText(templateJson(left = listOf("../steal.png")))
+        File(src, "bg.png").writeBytes(minimalPng)
+        File(src, "b.png").writeBytes(minimalPng)
+
+        assertThrows<TemplateLoadException> {
+            RemoteTemplateLoader.copyTemplateFromDirectory(src, templateRoot())
+        }
+        assertFalse(File(templateRoot(), "steal.png").exists())
+    }
+
+    @Test
+    fun `directory - duplicate without overwrite throws`() {
+        val src = File(tempDir, "src")
+        src.mkdirs()
+        File(src, "template.json").writeText(templateJson())
+        File(src, "bg.png").writeBytes(minimalPng)
+        File(src, "a.png").writeBytes(minimalPng)
+        File(src, "b.png").writeBytes(minimalPng)
+        val root = templateRoot()
+        RemoteTemplateLoader.copyTemplateFromDirectory(src, root)
+
+        assertThrows<RemoteTemplateLoader.TemplateExistsException> {
+            RemoteTemplateLoader.copyTemplateFromDirectory(src, root, overwrite = false)
+        }
+    }
+}

--- a/app/src/test/kotlin/app/floatdeck/data/RemoteTemplateLoaderSecurityTest.kt
+++ b/app/src/test/kotlin/app/floatdeck/data/RemoteTemplateLoaderSecurityTest.kt
@@ -1,0 +1,117 @@
+package app.floatdeck.data
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+
+/**
+ * Real unit tests for [RemoteTemplateLoader]'s security-critical logic.
+ * Calls internal companion functions directly (same-module visible, no Android Context),
+ * covering path traversal, ZIP bombs and id validation.
+ */
+class RemoteTemplateLoaderSecurityTest {
+    // ---------- safeResolveChild : path traversal defense ----------
+
+    @Test
+    fun `safeResolveChild accepts plain filename`() {
+        val base = File("/data/templates/tpl")
+        val resolved = RemoteTemplateLoader.safeResolveChild(base, "bg.png")
+        assertNotNull(resolved)
+        assertEquals(File("/data/templates/tpl/bg.png"), resolved)
+    }
+
+    @Test
+    fun `safeResolveChild rejects parent traversal`() {
+        val base = File("/data/templates/tpl")
+        assertNull(RemoteTemplateLoader.safeResolveChild(base, "../../etc/passwd"))
+        assertNull(RemoteTemplateLoader.safeResolveChild(base, "../sibling/secret"))
+    }
+
+    @Test
+    fun `safeResolveChild rejects absolute paths`() {
+        val base = File("/data/templates/tpl")
+        assertNull(RemoteTemplateLoader.safeResolveChild(base, "/etc/passwd"))
+        assertNull(RemoteTemplateLoader.safeResolveChild(base, "\\etc\\passwd"))
+    }
+
+    @Test
+    fun `safeResolveChild rejects windows drive letters`() {
+        val base = File("/data/templates/tpl")
+        assertNull(RemoteTemplateLoader.safeResolveChild(base, "C:evil"))
+    }
+
+    @Test
+    fun `safeResolveChild rejects sibling with same prefix`() {
+        val base = File("/data/templates/tpl")
+        // tpl-evil must not be treated as a child of tpl
+        assertNull(RemoteTemplateLoader.safeResolveChild(base, "../tpl-evil/secret"))
+    }
+
+    @Test
+    fun `safeResolveChild rejects blank`() {
+        val base = File("/data/templates/tpl")
+        assertNull(RemoteTemplateLoader.safeResolveChild(base, ""))
+        assertNull(RemoteTemplateLoader.safeResolveChild(base, "   "))
+    }
+
+    // ---------- isValidTemplateId ----------
+
+    @Test
+    fun `isValidTemplateId accepts safe ids`() {
+        assertTrue(RemoteTemplateLoader.isValidTemplateId("a"))
+        assertTrue(RemoteTemplateLoader.isValidTemplateId("my_template-1"))
+        assertTrue(RemoteTemplateLoader.isValidTemplateId("ABC_123-x"))
+    }
+
+    @Test
+    fun `isValidTemplateId rejects traversal and special chars`() {
+        assertFalse(RemoteTemplateLoader.isValidTemplateId(""))
+        assertFalse(RemoteTemplateLoader.isValidTemplateId("../etc"))
+        assertFalse(RemoteTemplateLoader.isValidTemplateId("a/b"))
+        assertFalse(RemoteTemplateLoader.isValidTemplateId("a id"))
+        assertFalse(RemoteTemplateLoader.isValidTemplateId("a:id"))
+    }
+
+    // ---------- copyToWithLimit : ZIP bomb defense ----------
+
+    @Test
+    fun `copyToWithLimit copies within limit`() {
+        val input = ByteArrayInputStream(ByteArray(100))
+        val out = ByteArrayOutputStream()
+        val written =
+            with(RemoteTemplateLoader) {
+                input.copyToWithLimit(out, 200)
+            }
+        assertEquals(100L, written)
+        assertEquals(100, out.size())
+    }
+
+    @Test
+    fun `copyToWithLimit throws when exceeding limit`() {
+        val input = ByteArrayInputStream(ByteArray(1000))
+        val out = ByteArrayOutputStream()
+        assertThrows<java.io.IOException> {
+            with(RemoteTemplateLoader) {
+                input.copyToWithLimit(out, 100)
+            }
+        }
+    }
+
+    @Test
+    fun `copyToWithLimit limit of zero rejects any byte`() {
+        val input = ByteArrayInputStream(byteArrayOf(1))
+        val out = ByteArrayOutputStream()
+        assertThrows<java.io.IOException> {
+            with(RemoteTemplateLoader) {
+                input.copyToWithLimit(out, 0)
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Directory import: resolve wallpaper/portrait paths via canonical-path comparison (safeResolveChild); reject entries escaping source/target dir. Previously File(sourceDir, name) allowed ../ traversal writes.
- ZIP extraction: authoritative byte-count limit per entry (copyToWithLimit) plus 200MB total-decompressed budget. ZipEntry.size is attacker-controlled and was the only cap, enabling decompression bombs.
- HTTP: instead of hard-rejecting, throw HttpProtocolException so the settings UI shows a confirmation dialog; if the user trusts the source (community- shared wallpaper packs), they can proceed. HTTPS passes through directly.
- deleteTemplate: validate id regex and canonical path before recursive delete.
- First pass: reject absolute paths instead of naive '..' substring match.
- Fix ZipInputStream closed prematurely by bufferedReader().readText() while scanning template.json; use readBytes() instead.
- Add real unit + integration tests covering safeResolveChild, copyToWithLimit, end-to-end zip/dir import, traversal rejection and overwrite handling.
- Enable unitTests.isReturnDefaultValues and add real org.json test impl so Log/JSON-backed code becomes unit-testable.