### PR TITLE
fix(wallpaper): fix lock/unlock transition broken by GL thread lifecycle change

### DIFF
--- a/app/src/main/kotlin/app/floatdeck/gl/FloatDeckRenderer.kt
+++ b/app/src/main/kotlin/app/floatdeck/gl/FloatDeckRenderer.kt
@@ -94,8 +94,8 @@ class FloatDeckRenderer(
     // ------------------------------------------------------------------
     // 锁屏/解锁过渡
     // ------------------------------------------------------------------
-    var transitionProgress = 0f
-    var targetTransition = 0f
+    @Volatile var transitionProgress = 0f
+    @Volatile var targetTransition = 0f
     private var isFirstFrame = true
 
     // ------------------------------------------------------------------
@@ -168,8 +168,8 @@ class FloatDeckRenderer(
 
     /** 解锁动画延迟（秒） */
     private val unlockDelaySeconds = 0.1f
-    private var unlockDelayTimer = 0f
-    private var isWaitingForUnlock = false
+    @Volatile private var unlockDelayTimer = 0f
+    @Volatile private var isWaitingForUnlock = false
 
     private val placeholderColors =
         intArrayOf(
@@ -360,22 +360,7 @@ class FloatDeckRenderer(
     fun onDrawFrame(gl: javax.microedition.khronos.opengles.GL10?) {
         GLES30.glClear(GLES30.GL_COLOR_BUFFER_BIT)
 
-        if (isFirstFrame) {
-            transitionProgress = targetTransition
-            isFirstFrame = false
-        }
-
-        // 解锁延迟动画
-        if (isWaitingForUnlock) {
-            unlockDelayTimer += 0.016f
-            if (unlockDelayTimer >= unlockDelaySeconds) {
-                isWaitingForUnlock = false
-                targetTransition = 0f
-            }
-        }
-
-        val diff = targetTransition - transitionProgress
-        transitionProgress += if (abs(diff) < 0.01f) diff else diff * 0.08f
+        updateTransition()
 
         swayTimeSeconds += 0.016f
         updateInertia()
@@ -389,6 +374,27 @@ class FloatDeckRenderer(
 
         drawBackgroundLayers()
         drawPortraits()
+    }
+
+    /**
+     * Advance the lock/unlock transition state (pure CPU, callable without rendering).
+     */
+    fun updateTransition() {
+        if (isFirstFrame) {
+            transitionProgress = targetTransition
+            isFirstFrame = false
+        }
+
+        if (isWaitingForUnlock) {
+            unlockDelayTimer += 0.016f
+            if (unlockDelayTimer >= unlockDelaySeconds) {
+                isWaitingForUnlock = false
+                targetTransition = 0f
+            }
+        }
+
+        val diff = targetTransition - transitionProgress
+        transitionProgress += if (abs(diff) < 0.01f) diff else diff * 0.08f
     }
 
     private fun updateInertia() {

--- a/app/src/main/kotlin/app/floatdeck/service/FloatDeckWallpaperService.kt
+++ b/app/src/main/kotlin/app/floatdeck/service/FloatDeckWallpaperService.kt
@@ -90,12 +90,14 @@ class FloatDeckWallpaperService : WallpaperService() {
                     addAction(Intent.ACTION_SCREEN_ON)
                     addAction(Intent.ACTION_USER_PRESENT)
                 }
-            // Android 14+ 必须显式指定导出标志，否则抛 SecurityException
+            // Android 14+ requires an explicit exported flag, otherwise SecurityException.
+            // Use EXPORTED: ACTION_USER_PRESENT is sent by a non-system_server process
+            // on some OEM ROMs (e.g. ASUS ZenUI) and would be blocked by NOT_EXPORTED.
             ContextCompat.registerReceiver(
                 this@FloatDeckWallpaperService,
                 lockReceiver,
                 filter,
-                ContextCompat.RECEIVER_NOT_EXPORTED,
+                ContextCompat.RECEIVER_EXPORTED,
             )
             // 热重载：监听设置变化
             getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -118,9 +120,14 @@ class FloatDeckWallpaperService : WallpaperService() {
             if (visible) {
                 sensorHandler.register()
                 startGLThread()
+                glThread?.setRendering(true)
             } else {
                 sensorHandler.unregister()
-                stopGLThread()
+                // Keep the GL thread alive: preserves EGL context and textures,
+                // only pauses rendering. updateTransition() still runs so the
+                // lock/unlock lerp completes while the screen is off, avoiding
+                // the template-reload stutter on screen-on.
+                glThread?.setRendering(false)
             }
         }
 
@@ -150,7 +157,7 @@ class FloatDeckWallpaperService : WallpaperService() {
         }
 
         private fun startGLThread() {
-            // 停止并等待旧线程退出，避免新旧线程争用同一 Surface/EGL
+            if (glThread?.isRunning == true) return
             stopGLThread()
             glThread =
                 GLWallpaperThread(
@@ -197,11 +204,15 @@ class GLWallpaperThread(
     var isRunning = true
         private set
 
+    /** Whether to perform GPU rendering + swap. Set to false when the screen is off; only updateTransition() runs. */
+    @Volatile
+    private var rendering = true
+
     /** 由外部（设置变更）置位，渲染循环检测到后重新加载模板/特效。 */
     @Volatile
     private var reloadRequested = true
 
-    /** 模板是否已加载（每线程独立；切换可见性会新建线程并重新加载）。 */
+    /** Whether the template has been loaded. Stays true across visibility changes since the GL thread is no longer recreated. */
     private var templateLoaded = false
 
     /** 标记 EGL/渲染器资源已就绪，finally 中据此决定是否调用 renderer.release()。 */
@@ -209,6 +220,10 @@ class GLWallpaperThread(
 
     fun requestStop() {
         isRunning = false
+    }
+
+    fun setRendering(enabled: Boolean) {
+        rendering = enabled
     }
 
     fun requestReload() {
@@ -229,22 +244,27 @@ class GLWallpaperThread(
             while (isRunning) {
                 frameStart = System.nanoTime()
 
-                // 平滑插值传感器值（低通滤波，系数 0.08）
-                renderer.smoothedRollX +=
-                    (sensorHandler.rollX - renderer.smoothedRollX) * 0.08f
-                renderer.smoothedPitchY +=
-                    (sensorHandler.pitchY - renderer.smoothedPitchY) * 0.08f
+                if (rendering) {
+                    // 平滑插值传感器值（低通滤波，系数 0.08）
+                    renderer.smoothedRollX +=
+                        (sensorHandler.rollX - renderer.smoothedRollX) * 0.08f
+                    renderer.smoothedPitchY +=
+                        (sensorHandler.pitchY - renderer.smoothedPitchY) * 0.08f
 
-                // 首帧或设置变更后重新加载模板/特效
-                if (!templateLoaded || reloadRequested) {
-                    loadConfigFromPrefs(prefs)
-                    templateLoaded = true
-                    reloadRequested = false
+                    // 首帧或设置变更后重新加载模板/特效
+                    if (!templateLoaded || reloadRequested) {
+                        loadConfigFromPrefs(prefs)
+                        templateLoaded = true
+                        reloadRequested = false
+                    }
+
+                    renderer.onDrawFrame(null)
+
+                    egl10?.eglSwapBuffers(eglDisplay, eglSurface)
+                } else {
+                    // Screen off: advance transition state only, no GPU rendering
+                    renderer.updateTransition()
                 }
-
-                renderer.onDrawFrame(null)
-
-                egl10?.eglSwapBuffers(eglDisplay, eglSurface)
                 paceFrame(frameStart)
             }
         } catch (e: InterruptedException) {

--- a/app/src/test/kotlin/app/floatdeck/gl/FloatDeckRendererTransitionTest.kt
+++ b/app/src/test/kotlin/app/floatdeck/gl/FloatDeckRendererTransitionTest.kt
@@ -1,0 +1,245 @@
+package app.floatdeck.gl
+
+import android.content.Context
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for the lock/unlock transition state machine in [FloatDeckRenderer].
+ *
+ * These tests exercise [FloatDeckRenderer.updateTransition],
+ * [FloatDeckRenderer.triggerLock], and [FloatDeckRenderer.triggerUnlock] —
+ * pure-CPU logic that must behave correctly even when the GL thread is not
+ * rendering (e.g. while the screen is off).
+ *
+ * A relaxed-mock Context is used because the constructor requires one, but
+ * the transition logic never touches it.
+ *
+ * Background — the bugs these tests guard against:
+ *  - triggerLock snapping transitionProgress to 1f caused an abrupt visual
+ *    jump when the screen turned on (the lerp was bypassed).
+ *  - updateTransition was only called from onDrawFrame, so when the GL
+ *    thread was paused the transition froze; by the time rendering resumed
+ *    the state was stale.
+ */
+class FloatDeckRendererTransitionTest {
+
+    private val context: Context = mockk(relaxed = true)
+    private lateinit var renderer: FloatDeckRenderer
+
+    @BeforeEach
+    fun setUp() {
+        renderer = FloatDeckRenderer(context)
+    }
+
+    /**
+     * Consume the one-time isFirstFrame snap so subsequent calls exercise
+     * the normal lerp path (8 % per call).
+     */
+    private fun consumeFirstFrame() {
+        renderer.updateTransition()
+    }
+
+    // ==================================================================
+    // triggerLock — must set target, must NOT snap progress
+    // ==================================================================
+
+    @Test
+    fun `triggerLock sets target to locked without snapping progress`() {
+        // Fresh renderer: progress 0, target 0 (unlocked / edges).
+        assertEquals(0f, renderer.transitionProgress)
+
+        renderer.triggerLock()
+
+        assertEquals(1f, renderer.targetTransition)
+        assertTrue(
+            renderer.transitionProgress < 0.1f,
+            "transitionProgress must not snap — it should lerp over many frames, " +
+                "got ${renderer.transitionProgress}",
+        )
+    }
+
+    @Test
+    fun `progress lerps gradually after triggerLock (regression for instant snap)`() {
+        consumeFirstFrame()
+        renderer.transitionProgress = 0f
+
+        renderer.triggerLock()
+        renderer.updateTransition()
+
+        assertTrue(
+            renderer.transitionProgress in 0.001f..0.2f,
+            "Progress should have moved ~8 % toward target, not snapped. " +
+                "Got ${renderer.transitionProgress}",
+        )
+    }
+
+    // ==================================================================
+    // updateTransition — lerp factor and convergence
+    // ==================================================================
+
+    @Test
+    fun `updateTransition moves 8 percent toward target per call`() {
+        consumeFirstFrame()
+        renderer.transitionProgress = 0f
+        renderer.targetTransition = 1f
+
+        renderer.updateTransition()
+
+        assertEquals(0.08f, renderer.transitionProgress, 0.001f)
+    }
+
+    @Test
+    fun `updateTransition converges to locked target within 60 calls`() {
+        consumeFirstFrame()
+        renderer.transitionProgress = 0f
+        renderer.targetTransition = 1f
+
+        repeat(60) { renderer.updateTransition() }
+
+        assertEquals(1f, renderer.transitionProgress, 0.001f)
+    }
+
+    @Test
+    fun `updateTransition never overshoots target`() {
+        consumeFirstFrame()
+        renderer.transitionProgress = 0f
+        renderer.targetTransition = 1f
+
+        repeat(100) {
+            renderer.updateTransition()
+            assertTrue(
+                renderer.transitionProgress <= 1.0f,
+                "Progress must never overshoot: got ${renderer.transitionProgress}",
+            )
+        }
+    }
+
+    // ==================================================================
+    // triggerUnlock — delay then transition to unlocked
+    // ==================================================================
+
+    @Test
+    fun `triggerUnlock leaves target unchanged during delay window`() {
+        // Start from locked state.
+        renderer.targetTransition = 1f
+        renderer.transitionProgress = 1f
+
+        renderer.triggerUnlock()
+
+        // unlockDelaySeconds = 0.1f; each call adds 0.016f.
+        // 6 calls × 0.016 = 0.096 < 0.1 → still waiting.
+        repeat(6) { renderer.updateTransition() }
+        assertEquals(
+            1f,
+            renderer.targetTransition,
+            "Target must remain locked during the unlock delay",
+        )
+    }
+
+    @Test
+    fun `triggerUnlock flips target to unlocked after delay`() {
+        renderer.targetTransition = 1f
+        renderer.transitionProgress = 1f
+
+        renderer.triggerUnlock()
+
+        // 7 calls × 0.016 = 0.112 ≥ 0.1 → delay elapses, target flips.
+        repeat(7) { renderer.updateTransition() }
+        assertEquals(0f, renderer.targetTransition)
+    }
+
+    @Test
+    fun `triggerUnlock eventually returns progress to edges`() {
+        renderer.targetTransition = 1f
+        renderer.transitionProgress = 1f
+
+        renderer.triggerUnlock()
+
+        // 7 calls for delay + ~60 calls for lerp = 67; use 70 for margin.
+        repeat(70) { renderer.updateTransition() }
+
+        assertEquals(0f, renderer.transitionProgress, 0.001f)
+    }
+
+    // ==================================================================
+    // triggerLock cancels pending unlock
+    // ==================================================================
+
+    @Test
+    fun `triggerLock cancels a pending unlock delay`() {
+        renderer.targetTransition = 1f
+        renderer.transitionProgress = 1f
+
+        renderer.triggerUnlock()
+        repeat(3) { renderer.updateTransition() } // part-way through delay
+
+        renderer.triggerLock()
+
+        assertEquals(1f, renderer.targetTransition)
+
+        // Even after many more calls, target must stay at 1 (no delayed flip to 0).
+        repeat(20) { renderer.updateTransition() }
+        assertEquals(1f, renderer.targetTransition)
+    }
+
+    // ==================================================================
+    // Full lock → unlock cycle
+    // ==================================================================
+
+    @Test
+    fun `lock then unlock full cycle returns progress to edges`() {
+        // --- Lock phase ---
+        renderer.triggerLock()
+        assertEquals(1f, renderer.targetTransition)
+        repeat(60) { renderer.updateTransition() }
+        assertEquals(1f, renderer.transitionProgress, 0.001f)
+
+        // --- Unlock phase ---
+        renderer.triggerUnlock()
+        repeat(70) { renderer.updateTransition() }
+        assertEquals(0f, renderer.transitionProgress, 0.001f)
+    }
+
+    @Test
+    fun `repeated lock unlock cycles are stable`() {
+        repeat(5) {
+            renderer.triggerLock()
+            repeat(60) { renderer.updateTransition() }
+            assertEquals(1f, renderer.transitionProgress, 0.01f)
+
+            renderer.triggerUnlock()
+            repeat(70) { renderer.updateTransition() }
+            assertEquals(0f, renderer.transitionProgress, 0.01f)
+        }
+    }
+
+    // ==================================================================
+    // isFirstFrame snap
+    // ==================================================================
+
+    @Test
+    fun `first updateTransition snaps progress to current target`() {
+        renderer.targetTransition = 1f
+        assertEquals(0f, renderer.transitionProgress)
+
+        renderer.updateTransition()
+
+        assertEquals(1f, renderer.transitionProgress)
+    }
+
+    @Test
+    fun `subsequent calls after first frame use lerp not snap`() {
+        // First call snaps to initial target (0).
+        renderer.updateTransition()
+
+        // Now change target — lerp should apply, not snap.
+        renderer.targetTransition = 1f
+        renderer.updateTransition()
+
+        assertEquals(0.08f, renderer.transitionProgress, 0.001f)
+    }
+}


### PR DESCRIPTION
- Change RECEIVER_NOT_EXPORTED → RECEIVER_EXPORTED: ACTION_USER_PRESENT is sent by a non-system_server process on some OEM ROMs (e.g. ASUS ZenUI) and was silently blocked, so unlock never triggered.
- Keep GL thread alive across visibility changes instead of stop/restart: add a 'rendering' flag so EGL context and textures stay resident, eliminating the template-reload stutter on screen-on.
- Extract updateTransition() from onDrawFrame() and call it even while not rendering, so the lock lerp completes while the screen is off and the first visible frame is already at the correct position.
- Add @Volatile to cross-thread transition fields for visibility.
- Add 13 regression tests covering triggerLock/triggerUnlock/updateTransition.