### PR TITLE
feat(settings): add portrait drag toggle with position reset

### DIFF
--- a/app/src/main/kotlin/app/floatdeck/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/floatdeck/data/SettingsRepository.kt
@@ -3,6 +3,7 @@ package app.floatdeck.data
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -26,6 +27,7 @@ class SettingsRepository(
         private val KEY_TEMPLATE = stringPreferencesKey("template_id")
         private val KEY_WALLPAPER_URI = stringPreferencesKey("wallpaper_uri")
         private val KEY_PORTRAIT_EFFECT = stringPreferencesKey("portrait_effect")
+        private val KEY_DRAG_ENABLED = booleanPreferencesKey("drag_enabled")
     }
 
     /** 当前选中的模板 ID。 */
@@ -67,7 +69,23 @@ class SettingsRepository(
             .apply()
     }
 
-    /** 保存壁纸 URI（传 null 则移除，恢复使用内置壁纸）。 */
+    /** Whether portrait drag is enabled, default true. */
+    val dragEnabled: Flow<Boolean> =
+        context.dataStore.data.map { prefs ->
+            prefs[KEY_DRAG_ENABLED] ?: true
+        }
+
+    /** Save portrait drag enabled state. */
+    suspend fun setDragEnabled(enabled: Boolean) {
+        context.dataStore.edit { it[KEY_DRAG_ENABLED] = enabled }
+        context
+            .getSharedPreferences("settings_prefs", Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean("drag_enabled", enabled)
+            .apply()
+    }
+
+    /** Save wallpaper URI (null removes it, reverting to the built-in wallpaper). */
     suspend fun setWallpaperUri(uri: String?) {
         context.dataStore.edit { prefs ->
             if (uri != null) {

--- a/app/src/main/kotlin/app/floatdeck/gl/FloatDeckRenderer.kt
+++ b/app/src/main/kotlin/app/floatdeck/gl/FloatDeckRenderer.kt
@@ -732,6 +732,17 @@ class FloatDeckRenderer(
         draggedPortraitIndex = -1
     }
 
+    /** Reset all portrait drag offsets and velocities to their default positions. */
+    fun resetDragOffsets() {
+        portraitStates.forEach { state ->
+            state.offsetX = 0f
+            state.offsetY = 0f
+            state.velocityX = 0f
+            state.velocityY = 0f
+        }
+        draggedPortraitIndex = -1
+    }
+
     fun onDoubleTap(
         touchX: Float,
         touchY: Float,

--- a/app/src/main/kotlin/app/floatdeck/service/FloatDeckWallpaperService.kt
+++ b/app/src/main/kotlin/app/floatdeck/service/FloatDeckWallpaperService.kt
@@ -26,6 +26,7 @@ private const val TAG = "FloatDeckWallpaper"
 private const val PREFS_NAME = "settings_prefs"
 private const val KEY_TEMPLATE_ID = "template_id"
 private const val KEY_PORTRAIT_EFFECT = "portrait_effect"
+private const val KEY_DRAG_ENABLED = "drag_enabled"
 
 /**
  * FloatDeck 动态壁纸服务入口。
@@ -46,8 +47,13 @@ class FloatDeckWallpaperService : WallpaperService() {
          * 使用强引用字段，避免 SharedPreferences 内部弱引用导致被 GC。
          */
         private val prefsListener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
-            if (key == KEY_TEMPLATE_ID || key == KEY_PORTRAIT_EFFECT) {
-                glThread?.requestReload()
+            when (key) {
+                KEY_TEMPLATE_ID, KEY_PORTRAIT_EFFECT -> glThread?.requestReload()
+                KEY_DRAG_ENABLED -> {
+                    val enabled = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                        .getBoolean(KEY_DRAG_ENABLED, true)
+                    if (!enabled) renderer.resetDragOffsets()
+                }
             }
         }
 
@@ -142,15 +148,19 @@ class FloatDeckWallpaperService : WallpaperService() {
         }
 
         override fun onTouchEvent(event: MotionEvent) {
-            when (event.action) {
-                MotionEvent.ACTION_DOWN -> {
-                    renderer.onTouchDown(event.x, event.y)
-                }
-                MotionEvent.ACTION_MOVE -> {
-                    renderer.onTouchMove(event.x, event.y)
-                }
-                MotionEvent.ACTION_UP -> {
-                    renderer.onTouchUp()
+            val dragEnabled = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .getBoolean(KEY_DRAG_ENABLED, true)
+            if (dragEnabled) {
+                when (event.action) {
+                    MotionEvent.ACTION_DOWN -> {
+                        renderer.onTouchDown(event.x, event.y)
+                    }
+                    MotionEvent.ACTION_MOVE -> {
+                        renderer.onTouchMove(event.x, event.y)
+                    }
+                    MotionEvent.ACTION_UP -> {
+                        renderer.onTouchUp()
+                    }
                 }
             }
             super.onTouchEvent(event)

--- a/app/src/main/kotlin/app/floatdeck/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/app/floatdeck/settings/SettingsActivity.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -112,6 +113,7 @@ fun SettingsScreen(
     val context = LocalContext.current
     var templateId by remember { mutableStateOf("") }
     var selectedEffect by remember { mutableStateOf(PortraitEffect.NONE) }
+    var dragEnabled by remember { mutableStateOf(true) }
     var remoteTemplates by remember { mutableStateOf<List<TemplateDef>>(emptyList()) }
     var urlText by remember { mutableStateOf("") }
     var isLoading by remember { mutableStateOf(false) }
@@ -134,6 +136,11 @@ fun SettingsScreen(
     remember {
         scope.launch {
             repo.portraitEffect.collect { selectedEffect = it }
+        }
+    }
+    remember {
+        scope.launch {
+            repo.dragEnabled.collect { dragEnabled = it }
         }
     }
 
@@ -367,6 +374,23 @@ fun SettingsScreen(
                     Text(
                         stringResource(effect.labelResId),
                         modifier = Modifier.padding(start = 8.dp),
+                    )
+                }
+            }
+
+            // Portrait drag toggle
+            item {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        stringResource(R.string.drag_enabled),
+                        modifier = Modifier.weight(1f),
+                    )
+                    Switch(
+                        checked = dragEnabled,
+                        onCheckedChange = { scope.launch { repo.setDragEnabled(it) } },
                     )
                 }
             }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -10,6 +10,7 @@
     <string name="effect_none">なし</string>
     <string name="effect_ice">氷</string>
     <string name="effect_holo">ホログラム</string>
+    <string name="drag_enabled">ドラッグを許可</string>
     <string name="import_remote_template">リモートテンプレートをインポート</string>
     <string name="import_remote_desc">ZIPのURLを入力してテンプレートをダウンロード・インポート</string>
     <string name="zip_url_label">ZIPのURL</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -10,6 +10,7 @@
     <string name="effect_none">없음</string>
     <string name="effect_ice">얼음</string>
     <string name="effect_holo">홀로그램</string>
+    <string name="drag_enabled">드래그 허용</string>
     <string name="import_remote_template">원격 템플릿 가져오기</string>
     <string name="import_remote_desc">ZIP URL을 입력해 템플릿을 다운로드하고 가져옵니다</string>
     <string name="zip_url_label">ZIP URL</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -10,6 +10,7 @@
     <string name="effect_none">无</string>
     <string name="effect_ice">碎碎冰</string>
     <string name="effect_holo">炫彩</string>
+    <string name="drag_enabled">允许拖拽</string>
     <string name="import_remote_template">导入远程模板</string>
     <string name="import_remote_desc">输入 ZIP 包 URL，从远程下载并导入模板</string>
     <string name="zip_url_label">ZIP 包 URL</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="effect_none">None</string>
     <string name="effect_ice">Ice</string>
     <string name="effect_holo">Holographic</string>
+    <string name="drag_enabled">Allow Drag</string>
     <string name="import_remote_template">Import Remote Template</string>
     <string name="import_remote_desc">Enter ZIP URL to download and import template</string>
     <string name="zip_url_label">ZIP URL</string>


### PR DESCRIPTION
- Add drag_enabled boolean setting (default true) persisted via DataStore + SharedPreferences dual-write.
- Settings UI: Switch below portrait effect section.
- WallpaperService: onTouchEvent skips drag logic when disabled.
- prefsListener resets all portrait offsets/velocities when drag is turned off, so cards snap back to default positions.
- Strings added for en/zh/ja/ko.