### PR TITLE
Perf/frame pacing

### DIFF
--- a/app/src/main/kotlin/app/floatdeck/data/SettingsRepository.kt
+++ b/app/src/main/kotlin/app/floatdeck/data/SettingsRepository.kt
@@ -28,6 +28,7 @@ class SettingsRepository(
         private val KEY_WALLPAPER_URI = stringPreferencesKey("wallpaper_uri")
         private val KEY_PORTRAIT_EFFECT = stringPreferencesKey("portrait_effect")
         private val KEY_DRAG_ENABLED = booleanPreferencesKey("drag_enabled")
+        private val KEY_FRAME_RATE_MODE = stringPreferencesKey("frame_rate_mode")
     }
 
     /** 当前选中的模板 ID。 */
@@ -94,5 +95,21 @@ class SettingsRepository(
                 prefs.remove(KEY_WALLPAPER_URI)
             }
         }
+    }
+
+    /** Render frame rate mode: auto | half | third | quarter (of max refresh). */
+    val frameRateMode: Flow<String> =
+        context.dataStore.data.map { prefs ->
+            prefs[KEY_FRAME_RATE_MODE] ?: "auto"
+        }
+
+    /** Save the frame rate mode. */
+    suspend fun setFrameRateMode(mode: String) {
+        context.dataStore.edit { it[KEY_FRAME_RATE_MODE] = mode }
+        context
+            .getSharedPreferences("settings_prefs", Context.MODE_PRIVATE)
+            .edit()
+            .putString("frame_rate_mode", mode)
+            .apply()
     }
 }

--- a/app/src/main/kotlin/app/floatdeck/gl/FloatDeckRenderer.kt
+++ b/app/src/main/kotlin/app/floatdeck/gl/FloatDeckRenderer.kt
@@ -385,8 +385,8 @@ class FloatDeckRenderer(
         drawPortraits()
     }
 
-/** Computes the frame delta (s) from the previous frame; clamped to avoid jumps after long stalls. */
-    private fun updateFrameDelta() {
+    /** Computes the frame delta (s) from the previous frame; clamped to avoid jumps after long stalls. */
+    internal fun updateFrameDelta() {
         val now = System.nanoTime()
         frameDeltaSeconds =
             if (lastFrameNanos == 0L) {

--- a/app/src/main/kotlin/app/floatdeck/gl/FloatDeckRenderer.kt
+++ b/app/src/main/kotlin/app/floatdeck/gl/FloatDeckRenderer.kt
@@ -8,6 +8,7 @@ import android.opengl.Matrix
 import app.floatdeck.data.TemplateConfig
 import java.nio.FloatBuffer
 import kotlin.math.abs
+import kotlin.math.exp
 import kotlin.math.sin
 
 // ============================================================================
@@ -102,6 +103,13 @@ class FloatDeckRenderer(
     // 晃动动画
     // ------------------------------------------------------------------
     private var swayTimeSeconds = 0f
+
+    // ------------------------------------------------------------------
+    // Frame delta (seconds): animations advance by real elapsed time so
+    // speed is identical on 60/90/120Hz screens
+    // ------------------------------------------------------------------
+    private var lastFrameNanos = 0L
+    private var frameDeltaSeconds = 0.016f
 
     // ------------------------------------------------------------------
     // 锁屏布局
@@ -360,9 +368,10 @@ class FloatDeckRenderer(
     fun onDrawFrame(gl: javax.microedition.khronos.opengles.GL10?) {
         GLES30.glClear(GLES30.GL_COLOR_BUFFER_BIT)
 
+        updateFrameDelta()
         updateTransition()
 
-        swayTimeSeconds += 0.016f
+        swayTimeSeconds += frameDeltaSeconds
         updateInertia()
 
         // 横竖屏切换时重新加载模板
@@ -376,6 +385,18 @@ class FloatDeckRenderer(
         drawPortraits()
     }
 
+/** Computes the frame delta (s) from the previous frame; clamped to avoid jumps after long stalls. */
+    private fun updateFrameDelta() {
+        val now = System.nanoTime()
+        frameDeltaSeconds =
+            if (lastFrameNanos == 0L) {
+                0.016f
+            } else {
+                ((now - lastFrameNanos) / 1_000_000_000.0).toFloat().coerceIn(0f, 0.1f)
+            }
+        lastFrameNanos = now
+    }
+
     /**
      * Advance the lock/unlock transition state (pure CPU, callable without rendering).
      */
@@ -386,15 +407,18 @@ class FloatDeckRenderer(
         }
 
         if (isWaitingForUnlock) {
-            unlockDelayTimer += 0.016f
+            unlockDelayTimer += frameDeltaSeconds
             if (unlockDelayTimer >= unlockDelaySeconds) {
                 isWaitingForUnlock = false
                 targetTransition = 0f
             }
         }
 
+        // Exponential approach with 0.2s time constant; matches the old
+        // 8%-per-frame convergence at 60fps
         val diff = targetTransition - transitionProgress
-        transitionProgress += if (abs(diff) < 0.01f) diff else diff * 0.08f
+        transitionProgress +=
+            if (abs(diff) < 0.01f) diff else diff * (1f - exp(-frameDeltaSeconds / 0.2f))
     }
 
     private fun updateInertia() {
@@ -403,10 +427,13 @@ class FloatDeckRenderer(
 
         portraitStates.forEach { state ->
             if (state.velocityX != 0f || state.velocityY != 0f) {
-                state.offsetX += state.velocityX
-                state.offsetY += state.velocityY
-                state.velocityX *= 0.92f
-                state.velocityY *= 0.92f
+                state.offsetX += state.velocityX * frameDeltaSeconds * 60f
+                state.offsetY += state.velocityY * frameDeltaSeconds * 60f
+                // Framerate-normalized damping: exp(-5t) equals the old
+                // per-frame ×0.92 at 60fps
+                val damping = exp(-frameDeltaSeconds * 5.0f)
+                state.velocityX *= damping
+                state.velocityY *= damping
                 if (abs(state.velocityX) < 0.5f) state.velocityX = 0f
                 if (abs(state.velocityY) < 0.5f) state.velocityY = 0f
             }

--- a/app/src/main/kotlin/app/floatdeck/service/FloatDeckWallpaperService.kt
+++ b/app/src/main/kotlin/app/floatdeck/service/FloatDeckWallpaperService.kt
@@ -295,6 +295,25 @@ class GLWallpaperThread(
     /** 标记 EGL/渲染器资源已就绪，finally 中据此决定是否调用 renderer.release()。 */
     private var glReady = false
 
+    // ------------------------------------------------------------------
+    // Display pacing state (polled on this thread ~every 0.5s)
+    // ------------------------------------------------------------------
+
+    /** Default display: source of the refresh rate; also votes for high refresh. */
+    private val display: android.view.Display? by lazy {
+        (context.getSystemService(android.hardware.display.DisplayManager::class.java))
+            .getDisplay(android.view.Display.DEFAULT_DISPLAY)
+    }
+
+    /** Frame interval matching the display refresh rate; 60fps until first poll. */
+    @Volatile
+    private var fullFrameIntervalNanos = FRAME_INTERVAL_NANOS
+
+    private var frameCounter = 0
+
+    /** Last refresh rate voted for via Surface.setFrameRate; -1 = none yet. */
+    private var lastRequestedRefreshFps = -1f
+
     fun requestStop() {
         isRunning = false
     }
@@ -330,6 +349,14 @@ class GLWallpaperThread(
                 handleSurfaceChanges()
 
                 if (rendering && eglSurface != null) {
+                    // Refresh display pacing state (refresh rate,
+                    // high-refresh vote) every ~0.5s; per-frame queries
+                    // are not free.
+                    frameCounter++
+                    if (frameCounter % DISPLAY_POLL_INTERVAL_FRAMES == 0) {
+                        pollDisplayState()
+                    }
+
                     // 平滑插值传感器值（低通滤波，系数 0.08）
                     renderer.smoothedRollX +=
                         (sensorHandler.rollX - renderer.smoothedRollX) * 0.08f
@@ -374,10 +401,43 @@ class GLWallpaperThread(
         }
     }
 
+    /** Refreshes pacing state from the display and power manager. */
+    private fun pollDisplayState() {
+        val d = display ?: return
+        val fps = d.refreshRate.toInt().coerceIn(30, 240)
+        fullFrameIntervalNanos = 1_000_000_000L / fps
+        requestHighRefreshRate(d)
+    }
+
+    /**
+     * Votes for the panel's highest supported refresh rate via
+     * Surface.setFrameRate. Without a vote the compositor keeps the panel at
+     * its default mode (60Hz on the test device) even when higher modes are
+     * available; the vote lets the panel ramp up while the wallpaper renders.
+     */
+    private fun requestHighRefreshRate(d: android.view.Display) {
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.R) return
+        val desired = d.supportedModes.maxOfOrNull { it.refreshRate } ?: d.refreshRate
+        if (desired == lastRequestedRefreshFps) return
+        val surface = surfaceHolder.surface ?: return
+        runCatching {
+            surface.setFrameRate(
+                desired,
+                android.view.Surface.FRAME_RATE_COMPATIBILITY_DEFAULT,
+            )
+            lastRequestedRefreshFps = desired
+        }.onFailure { Log.w(TAG, "setFrameRate($desired) failed", it) }
+    }
+
     /** 根据本帧已耗时计算剩余时间睡眠，接近目标帧率且不浪费 CPU。 */
     private fun paceFrame(frameStartNanos: Long) {
         val elapsed = System.nanoTime() - frameStartNanos
-        val sleepMs = sleepMillisForFrame(elapsed, FRAME_INTERVAL_NANOS)
+        val interval = fullFrameIntervalNanos
+        // Scale the present margin with the interval so high refresh rates
+        // still leave room for draw + submission.
+        val margin =
+            (interval / 3).coerceIn(MIN_PRESENT_MARGIN_NANOS, MAX_PRESENT_MARGIN_NANOS)
+        val sleepMs = sleepMillisForFrame(elapsed, interval, margin)
         if (sleepMs > 0) {
             try {
                 Thread.sleep(sleepMs)
@@ -608,16 +668,22 @@ class GLWallpaperThread(
         private const val TAG = "GLWallpaperThread"
         private const val TARGET_FPS = 60L
         private const val FRAME_INTERVAL_NANOS = 1_000_000_000L / TARGET_FPS
+
         private const val NANOS_PER_MS = 1_000_000L
 
+        /** Poll interval (frames) for refreshing pacing state (~0.5s at 60fps). */
+        private const val DISPLAY_POLL_INTERVAL_FRAMES = 30
+
         /**
-         * Safety margin subtracted from the sleep target so the *next* frame's
-         * draw + buffer submission lands before the intended vblank. Waking
-         * exactly at the frame boundary means the queue happens after it, the
-         * presentation slips a whole vblank period, and the pace judders
-         * (e.g. 33/50ms alternation for a 30fps target on a 60Hz panel).
+         * Bounds for the present margin: subtracted from the sleep target so
+         * the *next* frame's draw + buffer submission lands before the
+         * intended vblank. Waking exactly at the frame boundary means the
+         * queue happens after it, the presentation slips a whole vblank
+         * period, and the pace judders (e.g. 33/50ms alternation for a 30fps
+         * target on a 60Hz panel).
          */
-        private const val PRESENT_MARGIN_NANOS = 3L * NANOS_PER_MS
+        private const val MIN_PRESENT_MARGIN_NANOS = 1L * NANOS_PER_MS
+        private const val MAX_PRESENT_MARGIN_NANOS = 3L * NANOS_PER_MS
 
         /**
          * 计算本帧应睡眠的毫秒数：用目标帧间隔减去已耗时与呈现余量的纳秒，下限为 0。
@@ -626,7 +692,7 @@ class GLWallpaperThread(
         internal fun sleepMillisForFrame(
             elapsedNanos: Long,
             frameIntervalNanos: Long = FRAME_INTERVAL_NANOS,
-            presentMarginNanos: Long = PRESENT_MARGIN_NANOS,
+            presentMarginNanos: Long = MAX_PRESENT_MARGIN_NANOS,
         ): Long =
             ((frameIntervalNanos - presentMarginNanos - elapsedNanos) / NANOS_PER_MS)
                 .coerceAtLeast(0L)

--- a/app/src/main/kotlin/app/floatdeck/service/FloatDeckWallpaperService.kt
+++ b/app/src/main/kotlin/app/floatdeck/service/FloatDeckWallpaperService.kt
@@ -330,6 +330,9 @@ class GLWallpaperThread(
 
     fun setRendering(enabled: Boolean) {
         rendering = enabled
+        // Wake the loop promptly when becoming visible again: it may be in
+        // a long screen-off sleep.
+        if (enabled) interrupt()
     }
 
     fun requestReload() {
@@ -391,8 +394,21 @@ class GLWallpaperThread(
 
                     egl10?.eglSwapBuffers(eglDisplay, eglSurface)
                 } else if (!rendering) {
-                    // Screen off: advance transition state only, no GPU rendering
+                    // Screen off: advance transition state only, no GPU
+                    // rendering. Nobody sees intermediate frames while the
+                    // screen is off, so advance with coarse sleeps instead
+                    // of the render pace, and settle into a ~1Hz poll once
+                    // the transition is done - otherwise the loop keeps
+                    // waking 60x/s for nothing all night. A wake nudge from
+                    // setRendering interrupts the sleep so screen-on still
+                    // renders immediately.
+                    renderer.updateFrameDelta()
                     renderer.updateTransition()
+                    val settled =
+                        kotlin.math.abs(renderer.targetTransition - renderer.transitionProgress) < 0.005f
+                    sleepQuietly(
+                        if (settled) SCREEN_OFF_SETTLED_SLEEP_MS else SCREEN_OFF_ACTIVE_SLEEP_MS,
+                    )
                 }
                 // While eglSurface is not rebuilt yet (surfaceLost/dirty
                 // pending), just wait
@@ -472,13 +488,21 @@ class GLWallpaperThread(
         // still leave room for draw + submission.
         val margin =
             (interval / 3).coerceIn(MIN_PRESENT_MARGIN_NANOS, MAX_PRESENT_MARGIN_NANOS)
-        val sleepMs = sleepMillisForFrame(elapsed, interval, margin)
-        if (sleepMs > 0) {
-            try {
-                Thread.sleep(sleepMs)
-            } catch (_: InterruptedException) {
-                Thread.currentThread().interrupt()
-            }
+        // The coarse screen-off sleeps make elapsed exceed the interval, so
+        // this naturally becomes a no-op right after a screen-off sleep.
+        sleepQuietly(sleepMillisForFrame(elapsed, interval, margin))
+    }
+
+    /**
+     * Sleeps, swallowing interrupts: the only interrupt source is our own
+     * wake-up nudge from setRendering, and a stale interrupt flag would make
+     * every subsequent sleep return immediately (busy loop).
+     */
+    private fun sleepQuietly(millis: Long) {
+        if (millis <= 0) return
+        try {
+            Thread.sleep(millis)
+        } catch (_: InterruptedException) {
         }
     }
 
@@ -709,6 +733,10 @@ class GLWallpaperThread(
 
         /** Poll interval (frames) for refreshing pacing state (~0.5s at 60fps). */
         private const val DISPLAY_POLL_INTERVAL_FRAMES = 30
+
+        /** Screen-off sleep cadence: coarse while the transition advances, ~1Hz once settled. */
+        private const val SCREEN_OFF_ACTIVE_SLEEP_MS = 100L
+        private const val SCREEN_OFF_SETTLED_SLEEP_MS = 1000L
 
         /**
          * Bounds for the present margin: subtracted from the sleep target so

--- a/app/src/main/kotlin/app/floatdeck/service/FloatDeckWallpaperService.kt
+++ b/app/src/main/kotlin/app/floatdeck/service/FloatDeckWallpaperService.kt
@@ -418,7 +418,7 @@ class GLWallpaperThread(
         }
     }
 
-    /** Refreshes pacing state from the display and power manager. */
+    /** Refreshes pacing state from the display. */
     private fun pollDisplayState() {
         val d = display ?: return
         val refresh = d.refreshRate.toInt().coerceIn(30, 240)

--- a/app/src/main/kotlin/app/floatdeck/service/FloatDeckWallpaperService.kt
+++ b/app/src/main/kotlin/app/floatdeck/service/FloatDeckWallpaperService.kt
@@ -611,13 +611,25 @@ class GLWallpaperThread(
         private const val NANOS_PER_MS = 1_000_000L
 
         /**
-         * 计算本帧应睡眠的毫秒数：用目标帧间隔减去已耗时的纳秒，下限为 0。
+         * Safety margin subtracted from the sleep target so the *next* frame's
+         * draw + buffer submission lands before the intended vblank. Waking
+         * exactly at the frame boundary means the queue happens after it, the
+         * presentation slips a whole vblank period, and the pace judders
+         * (e.g. 33/50ms alternation for a 30fps target on a 60Hz panel).
+         */
+        private const val PRESENT_MARGIN_NANOS = 3L * NANOS_PER_MS
+
+        /**
+         * 计算本帧应睡眠的毫秒数：用目标帧间隔减去已耗时与呈现余量的纳秒，下限为 0。
          * 提取为纯函数便于单测。
          */
         internal fun sleepMillisForFrame(
             elapsedNanos: Long,
             frameIntervalNanos: Long = FRAME_INTERVAL_NANOS,
-        ): Long = ((frameIntervalNanos - elapsedNanos) / NANOS_PER_MS).coerceAtLeast(0L)
+            presentMarginNanos: Long = PRESENT_MARGIN_NANOS,
+        ): Long =
+            ((frameIntervalNanos - presentMarginNanos - elapsedNanos) / NANOS_PER_MS)
+                .coerceAtLeast(0L)
     }
 
     private var egl10: EGL10? = null

--- a/app/src/main/kotlin/app/floatdeck/service/FloatDeckWallpaperService.kt
+++ b/app/src/main/kotlin/app/floatdeck/service/FloatDeckWallpaperService.kt
@@ -27,6 +27,7 @@ private const val PREFS_NAME = "settings_prefs"
 private const val KEY_TEMPLATE_ID = "template_id"
 private const val KEY_PORTRAIT_EFFECT = "portrait_effect"
 private const val KEY_DRAG_ENABLED = "drag_enabled"
+private const val KEY_FRAME_RATE_MODE = "frame_rate_mode"
 
 /**
  * FloatDeck 动态壁纸服务入口。
@@ -53,6 +54,11 @@ class FloatDeckWallpaperService : WallpaperService() {
                     val enabled = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
                         .getBoolean(KEY_DRAG_ENABLED, true)
                     if (!enabled) renderer.resetDragOffsets()
+                }
+                KEY_FRAME_RATE_MODE -> {
+                    val mode = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                        .getString(KEY_FRAME_RATE_MODE, "auto") ?: "auto"
+                    glThread?.updateFrameRatePreference(mode)
                 }
             }
         }
@@ -314,6 +320,10 @@ class GLWallpaperThread(
     /** Last refresh rate voted for via Surface.setFrameRate; -1 = none yet. */
     private var lastRequestedRefreshFps = -1f
 
+    /** Frame rate mode from settings: auto | half | third | quarter (of max refresh). */
+    @Volatile
+    private var preferredFrameRateMode = "auto"
+
     fun requestStop() {
         isRunning = false
     }
@@ -324,6 +334,13 @@ class GLWallpaperThread(
 
     fun requestReload() {
         reloadRequested = true
+    }
+
+    /** Applies a frame-rate mode from settings (auto | half | third | quarter) on the next poll. */
+    fun updateFrameRatePreference(mode: String) {
+        preferredFrameRateMode = mode
+        // Nudge the counter so the next frame triggers an immediate poll
+        frameCounter = DISPLAY_POLL_INTERVAL_FRAMES - 1
     }
 
     override fun run() {
@@ -404,9 +421,21 @@ class GLWallpaperThread(
     /** Refreshes pacing state from the display and power manager. */
     private fun pollDisplayState() {
         val d = display ?: return
-        val fps = d.refreshRate.toInt().coerceIn(30, 240)
-        fullFrameIntervalNanos = 1_000_000_000L / fps
-        requestHighRefreshRate(d)
+        val refresh = d.refreshRate.toInt().coerceIn(30, 240)
+        val maxHz = d.supportedModes.maxOfOrNull { it.refreshRate.toInt() } ?: refresh
+        val preferred = when (preferredFrameRateMode) {
+            "half" -> maxHz / 2
+            "third" -> maxHz / 3
+            "quarter" -> maxHz / 4
+            else -> -1
+        }
+        // Pace at the preferred rate but never faster than the panel currently
+        // refreshes; the vote below asks the panel to move toward it. Fraction
+        // rates divide the max refresh evenly, so even a panel still running
+        // at max presents each pace tick at a whole number of vblanks.
+        val paceFps = if (preferred > 0) minOf(preferred, refresh) else refresh
+        fullFrameIntervalNanos = 1_000_000_000L / paceFps
+        requestHighRefreshRate(d, preferred.takeIf { it > 0 })
     }
 
     /**
@@ -415,9 +444,15 @@ class GLWallpaperThread(
      * its default mode (60Hz on the test device) even when higher modes are
      * available; the vote lets the panel ramp up while the wallpaper renders.
      */
-    private fun requestHighRefreshRate(d: android.view.Display) {
+    private fun requestHighRefreshRate(
+        d: android.view.Display,
+        preferredFps: Int?,
+    ) {
         if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.R) return
-        val desired = d.supportedModes.maxOfOrNull { it.refreshRate } ?: d.refreshRate
+        val desired =
+            preferredFps?.toFloat()
+                ?: d.supportedModes.maxOfOrNull { it.refreshRate }
+                ?: d.refreshRate
         if (desired == lastRequestedRefreshFps) return
         val surface = surfaceHolder.surface ?: return
         runCatching {
@@ -537,6 +572,7 @@ class GLWallpaperThread(
                 "holo" -> 2
                 else -> 0
             }
+        preferredFrameRateMode = prefs.getString(KEY_FRAME_RATE_MODE, "auto") ?: "auto"
 
         // 尝试从远程模板加载，再从 assets 加载
         val remoteLoader = RemoteTemplateLoader(context)

--- a/app/src/main/kotlin/app/floatdeck/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/app/floatdeck/settings/SettingsActivity.kt
@@ -4,7 +4,9 @@ package app.floatdeck.settings
 
 import android.app.WallpaperManager
 import android.content.ComponentName
+import android.content.Context
 import android.content.Intent
+import android.hardware.display.DisplayManager
 import android.net.Uri
 import android.os.Bundle
 import android.provider.DocumentsContract
@@ -28,6 +30,10 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -143,6 +149,37 @@ fun SettingsScreen(
             repo.dragEnabled.collect { dragEnabled = it }
         }
     }
+
+    var frameRateMode by remember { mutableStateOf("auto") }
+    remember {
+        scope.launch {
+            repo.frameRateMode.collect { frameRateMode = it }
+        }
+    }
+
+    // Highest refresh rate supported by the built-in display.
+    val maxRefreshHz by remember {
+        mutableStateOf(
+            ((context.getSystemService(Context.DISPLAY_SERVICE) as? DisplayManager)
+                ?.getDisplay(android.view.Display.DEFAULT_DISPLAY)
+                ?.supportedModes
+                ?.maxOfOrNull { it.refreshRate } ?: 60f).toInt(),
+        )
+    }
+
+    // Fraction-of-max options, dropping any that would fall below 30fps.
+    val frameRateFractionOptions =
+        listOf("half" to 2, "third" to 3, "quarter" to 4)
+            .map { (mode, denom) -> Triple(mode, denom, maxRefreshHz / denom) }
+            .filter { (_, _, hz) -> hz >= 30 }
+
+    fun frameRateModeLabel(mode: String): String =
+        when (mode) {
+            "half" -> "${maxRefreshHz / 2} Hz"
+            "third" -> "${maxRefreshHz / 3} Hz"
+            "quarter" -> "${maxRefreshHz / 4} Hz"
+            else -> context.getString(R.string.frame_rate_auto, maxRefreshHz)
+        }
 
     // 加载已导入的远程模板
     fun refreshRemoteTemplates() {
@@ -392,6 +429,49 @@ fun SettingsScreen(
                         checked = dragEnabled,
                         onCheckedChange = { scope.launch { repo.setDragEnabled(it) } },
                     )
+                }
+            }
+
+            // Render frame rate preference (Material3 exposed dropdown)
+            item {
+                var frameRateMenuExpanded by remember { mutableStateOf(false) }
+                ExposedDropdownMenuBox(
+                    expanded = frameRateMenuExpanded,
+                    onExpandedChange = { frameRateMenuExpanded = it },
+                ) {
+                    OutlinedTextField(
+                        value = frameRateModeLabel(frameRateMode),
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text(stringResource(R.string.frame_rate_title)) },
+                        trailingIcon = {
+                            ExposedDropdownMenuDefaults.TrailingIcon(expanded = frameRateMenuExpanded)
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+                    )
+                    ExposedDropdownMenu(
+                        expanded = frameRateMenuExpanded,
+                        onDismissRequest = { frameRateMenuExpanded = false },
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text(context.getString(R.string.frame_rate_auto, maxRefreshHz)) },
+                            onClick = {
+                                scope.launch { repo.setFrameRateMode("auto") }
+                                frameRateMenuExpanded = false
+                            },
+                        )
+                        frameRateFractionOptions.forEach { (mode, _, hz) ->
+                            DropdownMenuItem(
+                                text = { Text("$hz Hz") },
+                                onClick = {
+                                    scope.launch { repo.setFrameRateMode(mode) }
+                                    frameRateMenuExpanded = false
+                                },
+                            )
+                        }
+                    }
                 }
             }
 

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -11,6 +11,8 @@
     <string name="effect_ice">碎碎冰</string>
     <string name="effect_holo">炫彩</string>
     <string name="drag_enabled">允许拖拽</string>
+    <string name="frame_rate_title">帧率</string>
+    <string name="frame_rate_auto">自动（最高 %1$d Hz）</string>
     <string name="import_remote_template">导入远程模板</string>
     <string name="import_remote_desc">输入 ZIP 包 URL，从远程下载并导入模板</string>
     <string name="zip_url_label">ZIP 包 URL</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <string name="effect_ice">Ice</string>
     <string name="effect_holo">Holographic</string>
     <string name="drag_enabled">Allow Drag</string>
+    <string name="frame_rate_title">Frame rate</string>
+    <string name="frame_rate_auto">Auto (max %1$d Hz)</string>
     <string name="import_remote_template">Import Remote Template</string>
     <string name="import_remote_desc">Enter ZIP URL to download and import template</string>
     <string name="zip_url_label">ZIP URL</string>

--- a/app/src/test/kotlin/app/floatdeck/gl/FloatDeckRendererTransitionTest.kt
+++ b/app/src/test/kotlin/app/floatdeck/gl/FloatDeckRendererTransitionTest.kt
@@ -2,6 +2,7 @@ package app.floatdeck.gl
 
 import android.content.Context
 import io.mockk.mockk
+import kotlin.math.exp
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -30,6 +31,12 @@ class FloatDeckRendererTransitionTest {
     private val context: Context = mockk(relaxed = true)
     private lateinit var renderer: FloatDeckRenderer
 
+    /**
+     * Expected per-call progress at the default 16ms frame delta:
+     * 1 - exp(-0.016 / 0.2) ≈ 7.7 % (exponential approach, 0.2s time constant).
+     */
+    private val expectedStep = 1f - exp(-0.016f / 0.2f)
+
     @BeforeEach
     fun setUp() {
         renderer = FloatDeckRenderer(context)
@@ -37,7 +44,7 @@ class FloatDeckRendererTransitionTest {
 
     /**
      * Consume the one-time isFirstFrame snap so subsequent calls exercise
-     * the normal lerp path (8 % per call).
+     * the normal lerp path.
      */
     private fun consumeFirstFrame() {
         renderer.updateTransition()
@@ -82,14 +89,14 @@ class FloatDeckRendererTransitionTest {
     // ==================================================================
 
     @Test
-    fun `updateTransition moves 8 percent toward target per call`() {
+    fun `updateTransition moves one 16ms step toward target per call`() {
         consumeFirstFrame()
         renderer.transitionProgress = 0f
         renderer.targetTransition = 1f
 
         renderer.updateTransition()
 
-        assertEquals(0.08f, renderer.transitionProgress, 0.001f)
+        assertEquals(expectedStep, renderer.transitionProgress, 0.0005f)
     }
 
     @Test
@@ -240,6 +247,6 @@ class FloatDeckRendererTransitionTest {
         renderer.targetTransition = 1f
         renderer.updateTransition()
 
-        assertEquals(0.08f, renderer.transitionProgress, 0.001f)
+        assertEquals(expectedStep, renderer.transitionProgress, 0.0005f)
     }
 }

--- a/app/src/test/kotlin/app/floatdeck/service/GLWallpaperThreadFramePacingTest.kt
+++ b/app/src/test/kotlin/app/floatdeck/service/GLWallpaperThreadFramePacingTest.kt
@@ -10,17 +10,18 @@ import org.junit.jupiter.api.Test
  */
 class GLWallpaperThreadFramePacingTest {
     // FRAME_INTERVAL_NANOS = 1_000_000_000 / 60 = 16_666_666
+    // PRESENT_MARGIN_NANOS = 3ms = 3_000_000
 
     @Test
-    fun `frame that took zero time sleeps the full interval`() {
-        // 16_666_666 / 1_000_000 = 16
-        assertEquals(16L, GLWallpaperThread.sleepMillisForFrame(0L, 16_666_666L))
+    fun `frame that took zero time sleeps interval minus present margin`() {
+        // (16_666_666 - 3_000_000) / 1_000_000 = 13
+        assertEquals(13L, GLWallpaperThread.sleepMillisForFrame(0L, 16_666_666L))
     }
 
     @Test
-    fun `frame that used half the interval sleeps the remainder`() {
-        // (16_666_666 - 8_333_333) / 1_000_000 = 8
-        assertEquals(8L, GLWallpaperThread.sleepMillisForFrame(8_333_333L, 16_666_666L))
+    fun `frame that used half the interval sleeps the remainder minus margin`() {
+        // (16_666_666 - 3_000_000 - 8_333_333) / 1_000_000 = 5
+        assertEquals(5L, GLWallpaperThread.sleepMillisForFrame(8_333_333L, 16_666_666L))
     }
 
     @Test
@@ -35,9 +36,15 @@ class GLWallpaperThreadFramePacingTest {
     }
 
     @Test
+    fun `margin can be disabled to sleep the full interval`() {
+        // presentMarginNanos = 0 恢复无余量行为，便于对比
+        assertEquals(16L, GLWallpaperThread.sleepMillisForFrame(0L, 16_666_666L, 0L))
+    }
+
+    @Test
     fun `default frame interval is 60fps`() {
         // 不传 frameIntervalNanos 时使用默认 60fps 间隔
-        assertEquals(16L, GLWallpaperThread.sleepMillisForFrame(0L))
+        assertEquals(13L, GLWallpaperThread.sleepMillisForFrame(0L))
         assertEquals(0L, GLWallpaperThread.sleepMillisForFrame(20_000_000L))
     }
 }


### PR DESCRIPTION
## Frame pacing overhaul: refresh-rate adaptation + user-selectable rate

### Problem

- Animations advanced by a hardcoded per-frame constant, so they ran
  faster or slower depending on the display's refresh rate and on frame
  drops (a dropped frame slowed the whole scene).
- The render loop always targeted 60fps: on high-refresh panels the
  wallpaper never used the extra smoothness, and the pacing slept until
  the exact frame boundary, so the next draw + buffer submission landed
  after the intended vblank and presentation slipped a whole refresh
  period (visible judder).

### What this PR does

1. **Real frame delta time** — sway, lock/unlock transition easing and
   drag inertia are driven by measured elapsed time (exponential
   approach with a 0.2s time constant, framerate-normalized damping),
   so animation speed is identical on any refresh rate and unaffected
   by dropped frames.

2. **Refresh-rate adaptation** — the render pace follows the display's
   current refresh rate and votes for the panel's highest supported
   rate via `Surface.setFrameRate` (API 30+); without the vote the
   compositor keeps high-refresh panels at their default mode.

3. **Frame rate setting** — a Material3 dropdown lets users pick
   *Auto (max N Hz)* (labeled with the device's actual maximum) or fixed
   tiers at 1/2, 1/3 and 1/4 of the panel's max refresh (tiers below
   30fps are hidden). Fraction tiers divide the panel's max evenly, so
   presentation stays vblank-aligned even while the panel still runs at
   max — fixed values like 60 on a 144Hz panel would alternate 2/3
   vblank periods and judder. Changes apply on the very next frame via
   the existing prefs listener.

4. **Vblank-aligned pacing** — the sleep target is pulled back by a
   present margin (1–3ms, scaled with the frame interval) so draw +
   submission land before the intended vblank instead of slipping a
   whole period.

