### PR TITLE
feat(build): separate dev app identity for debug builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,6 +114,9 @@ android {
     buildTypes {
         debug {
             isMinifyEnabled = false
+            // Dev builds install alongside the release app under a separate
+            // applicationId so their data sandboxes stay fully independent.
+            applicationIdSuffix = ".dev"
         }
         release {
             isMinifyEnabled = true

--- a/app/src/debug/res/values-ja/strings.xml
+++ b/app/src/debug/res/values-ja/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">FloatDeck Dev</string>
+</resources>

--- a/app/src/debug/res/values-ko/strings.xml
+++ b/app/src/debug/res/values-ko/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">FloatDeck Dev</string>
+</resources>

--- a/app/src/debug/res/values-zh/strings.xml
+++ b/app/src/debug/res/values-zh/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">FloatDeck Dev</string>
+</resources>

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">FloatDeck Dev</string>
+</resources>


### PR DESCRIPTION
Debug builds now install as "FloatDeck Dev" (app.floatdeck.dev) alongside the release app, so test sessions never touch production data and the two sandboxes stay fully independent.

- debug build type gets applicationIdSuffix ".dev"; release is unchanged (app.floatdeck)
- override app_name in a debug source set for every locale that defines it (values, zh, ja, ko) — locale-qualified strings would otherwise win over an unqualified override on those devices