### PR TITLE
ci: run shader validation only when shader sources change

### DIFF
--- a/.github/workflows/shader-validation.yml
+++ b/.github/workflows/shader-validation.yml
@@ -3,8 +3,14 @@ name: Shader Validation
 on:
   push:
     branches: [main]
+    paths:
+      - 'app/src/main/kotlin/app/floatdeck/gl/Shaders.kt'
+      - '.github/workflows/shader-validation.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'app/src/main/kotlin/app/floatdeck/gl/Shaders.kt'
+      - '.github/workflows/shader-validation.yml'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The workflow's only input is the GLSL embedded in Shaders.kt, so gate both the push and pull_request triggers on that file (plus the workflow file itself) instead of running on every change to main.